### PR TITLE
Let goreleaser manage versioning via ldflags

### DIFF
--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -4,20 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
 
 	"github.com/a-h/templ/cmd/templ/fmtcmd"
 	"github.com/a-h/templ/cmd/templ/generatecmd"
 	"github.com/a-h/templ/cmd/templ/lspcmd"
 )
 
-func version() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "unknown"
-	}
-	return info.Main.Version
-}
+var version = "devel"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -35,10 +28,10 @@ func main() {
 		lspCmd(os.Args[2:])
 		return
 	case "version":
-		fmt.Println(version())
+		fmt.Println(version)
 		return
 	case "--version":
-		fmt.Println(version())
+		fmt.Println(version)
 		return
 	}
 	usage()


### PR DESCRIPTION
I noticed running `templ version` prints `devel` even when using a release downloaded from github releases.

Since goreleaser sets main.version via ldflags this should ensure it's picked up. I think it's possible to use ReadBuildInfo with goreleaser but requires some additional config.

I tested this using the dry run feature of goreleaser which seemed to work.

```
make build-snapshot
./dist/templ_darwin_amd64/templ version
v0.0.98-next
```