### PR TITLE
fix: ensure that both binary (goreleaser) and source (go install) builds get version numbers

### DIFF
--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -4,20 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime/debug"
 
 	"github.com/a-h/templ/cmd/templ/fmtcmd"
 	"github.com/a-h/templ/cmd/templ/generatecmd"
 	"github.com/a-h/templ/cmd/templ/lspcmd"
 )
 
-func version() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "unknown"
-	}
-	return info.Main.Version
-}
+var version = "devel"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -35,10 +28,10 @@ func main() {
 		lspCmd(os.Args[2:])
 		return
 	case "version":
-		fmt.Println(version())
+		fmt.Println(version)
 		return
 	case "--version":
-		fmt.Println(version())
+		fmt.Println(version)
 		return
 	}
 	usage()

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -4,13 +4,32 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/a-h/templ/cmd/templ/fmtcmd"
 	"github.com/a-h/templ/cmd/templ/generatecmd"
 	"github.com/a-h/templ/cmd/templ/lspcmd"
 )
 
-var version = "devel"
+// Binary builds set this version string. goreleaser sets the value using Go build ldflags.
+var version string
+
+// Source builds use this value. When installed using `go install github.com/a-h/templ/cmd/templ@latest` the `version` variable is empty, but
+// the debug.ReadBuildInfo return value provides the package version number installed by `go install`
+func goInstallVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	return info.Main.Version
+}
+
+func getVersion() string {
+	if version != "" {
+		return version
+	}
+	return goInstallVersion()
+}
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
Closes #13