### PR TITLE
Write files to buffer rather than directly to files

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -1,6 +1,7 @@
 package generatecmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -42,9 +43,13 @@ func compile(fileName string) (err error) {
 	if err != nil {
 		return fmt.Errorf("%s compilation error: %w", fileName, err)
 	}
-	_, err = generator.Generate(t, w)
+	b := bufio.NewWriter(w)
+	_, err = generator.Generate(t, b)
 	if err != nil {
 		return fmt.Errorf("%s generation error: %w", fileName, err)
+	}
+	if b.Flush() != nil {
+		return fmt.Errorf("%s write file error: %w", targetFileName, err)
 	}
 	return
 }


### PR DESCRIPTION
After some profiling of the generate command I had some interesting results.

I created a 10MB templ file which is the largest allowed then profiled the generation of it.

Ignoring any small effects profiling had on the speed it took around 2 minutes 50 seconds consistently.
Peaking at around 20MB allocated memory.

According to pprof the majority of this was time spent in `syscall`.
Using a file as an io.Reader was calling syscall a lot, which is slow.

So I tried writing to a buffer then writing the buffer and reduced this drastically.

It took about 8 seconds with a similar memory peak.