### PR TITLE
feat: stop enforcing spaces after '{%' and before '%}' (#35)

### DIFF
--- a/parser/calltemplateparser_test.go
+++ b/parser/calltemplateparser_test.go
@@ -34,6 +34,48 @@ func TestCallTemplateExpressionParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "call: simple, missing start space",
+			input: `{%!Other(p.Test) %}`,
+			expected: CallTemplateExpression{
+				Expression: Expression{
+					Value: "Other(p.Test)",
+					Range: Range{
+						From: Position{
+							Index: 3,
+							Line:  1,
+							Col:   3,
+						},
+						To: Position{
+							Index: 16,
+							Line:  1,
+							Col:   16,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "call: simple, missing start and end space",
+			input: `{%!Other(p.Test)%}`,
+			expected: CallTemplateExpression{
+				Expression: Expression{
+					Value: "Other(p.Test)",
+					Range: Range{
+						From: Position{
+							Index: 3,
+							Line:  1,
+							Col:   3,
+						},
+						To: Position{
+							Index: 16,
+							Line:  1,
+							Col:   16,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/parser/cssparser.go
+++ b/parser/cssparser.go
@@ -17,7 +17,7 @@ func newCSSParser() cssParser {
 type cssParser struct {
 }
 
-var endCssParser = parse.String("{% endcss %}") // {% endcss %}
+var endCssParser = createEndParser("endcss") // {% endcss %}
 
 func (p cssParser) Parse(pi parse.Input) parse.Result {
 	r := CSSTemplate{
@@ -84,6 +84,8 @@ func newCSSExpressionParser() cssExpressionParser {
 type cssExpressionParser struct {
 }
 
+var cssExpressionStartParser = createStartParser("css")
+
 var cssExpressionNameParser = parse.All(parse.WithStringConcatCombiner,
 	parse.Letter,
 	parse.Many(parse.WithStringConcatCombiner, 0, 1000, parse.Any(parse.Letter, parse.ZeroToNine)),
@@ -93,7 +95,7 @@ func (p cssExpressionParser) Parse(pi parse.Input) parse.Result {
 	var r cssExpression
 
 	// Check the prefix first.
-	prefixResult := parse.String("{% css ")(pi)
+	prefixResult := cssExpressionStartParser(pi)
 	if !prefixResult.Success {
 		return prefixResult
 	}
@@ -134,8 +136,8 @@ func (p cssExpressionParser) Parse(pi parse.Input) parse.Result {
 
 	// Eat ") %}".
 	from = NewPositionFromInput(pi)
-	if lb := parse.String(") %}")(pi); !lb.Success {
-		return parse.Failure("cssExpressionParser", newParseError("css expression: unterminated (missing ' %}')", from, NewPositionFromInput(pi)))
+	if lb := expressionFuncEnd(pi); !lb.Success {
+		return parse.Failure("cssExpressionParser", newParseError("css expression: unterminated (missing ') %}')", from, NewPositionFromInput(pi)))
 	}
 
 	// Expect a newline.

--- a/parser/cssparser_test.go
+++ b/parser/cssparser_test.go
@@ -119,6 +119,29 @@ func TestCSSParser(t *testing.T) {
 			},
 		},
 		{
+			name: "css: without spaces",
+			input: `{%css Name()%}
+{% endcss %}`,
+			expected: CSSTemplate{
+				Name: Expression{
+					Value: "Name",
+					Range: Range{
+						From: Position{
+							Index: 6,
+							Line:  1,
+							Col:   6,
+						},
+						To: Position{
+							Index: 10,
+							Line:  1,
+							Col:   10,
+						},
+					},
+				},
+				Properties: []CSSProperty{},
+			},
+		},
+		{
 			name: "css: single constant property",
 			input: `{% css Name() %}
 background-color: #ffffff;

--- a/parser/doctypeparser.go
+++ b/parser/doctypeparser.go
@@ -13,11 +13,13 @@ func newDocTypeParser() docTypeParser {
 type docTypeParser struct {
 }
 
+var doctypeStartParser = parse.StringInsensitive("<!doctype ")
+
 func (p docTypeParser) Parse(pi parse.Input) parse.Result {
 	var r DocType
 
 	from := NewPositionFromInput(pi)
-	dtr := parse.StringInsensitive("<!doctype ")(pi)
+	dtr := doctypeStartParser(pi)
 	if dtr.Error != nil && dtr.Error != io.EOF {
 		return dtr
 	}

--- a/parser/elementparser_test.go
+++ b/parser/elementparser_test.go
@@ -76,6 +76,29 @@ func TestAttributeParser(t *testing.T) {
 			},
 		},
 		{
+			name:   "boolean expression attribute without spaces",
+			input:  ` noshade?={%=true%}"`,
+			parser: newBoolExpressionAttributeParser().Parse,
+			expected: BoolExpressionAttribute{
+				Name: "noshade",
+				Expression: Expression{
+					Value: "true",
+					Range: Range{
+						From: Position{
+							Index: 13,
+							Line:  1,
+							Col:   13,
+						},
+						To: Position{
+							Index: 17,
+							Line:  1,
+							Col:   17,
+						},
+					},
+				},
+			},
+		},
+		{
 			name:   "attribute parsing handles boolean expression attributes",
 			input:  ` noshade?={%= true %}`,
 			parser: attributeParser,

--- a/parser/forexpressionparser_test.go
+++ b/parser/forexpressionparser_test.go
@@ -65,6 +65,58 @@ func TestForExpressionParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "for: simple, without spaces",
+			input: `{%for _, item := range p.Items%}
+					<div>{%= item %}</div>
+				{% endfor %}`,
+			expected: ForExpression{
+				Expression: Expression{
+					Value: `_, item := range p.Items`,
+					Range: Range{
+						From: Position{
+							Index: 6,
+							Line:  1,
+							Col:   6,
+						},
+						To: Position{
+
+							Index: 30,
+							Line:  1,
+							Col:   30,
+						},
+					},
+				},
+				Children: []Node{
+					Whitespace{Value: "\t\t\t\t\t"},
+					Element{
+						Name:       "div",
+						Attributes: []Attribute{},
+						Children: []Node{
+							StringExpression{
+								Expression: Expression{
+									Value: `item`,
+									Range: Range{
+										From: Position{
+											Index: 47,
+											Line:  2,
+											Col:   14,
+										},
+										To: Position{
+
+											Index: 51,
+											Line:  2,
+											Col:   18,
+										},
+									},
+								},
+							},
+						},
+					},
+					Whitespace{Value: "\n\t\t\t\t"},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/parser/ifexpressionparser_test.go
+++ b/parser/ifexpressionparser_test.go
@@ -136,6 +136,128 @@ func TestIfExpression(t *testing.T) {
 			},
 		},
 		{
+			name: "if: simple expression, without spaces",
+			input: `{%if p.Test%}
+<span>
+  {%= "span content" %}
+</span>
+{%endif%}
+`,
+			expected: IfExpression{
+				Expression: Expression{
+					Value: `p.Test`,
+					Range: Range{
+						From: Position{
+							Index: 5,
+							Line:  1,
+							Col:   5,
+						},
+						To: Position{
+							Index: 11,
+							Line:  1,
+							Col:   11,
+						},
+					},
+				},
+				Then: []Node{
+					Element{
+						Name:       "span",
+						Attributes: []Attribute{},
+						Children: []Node{
+							Whitespace{Value: "\n  "},
+							StringExpression{
+								Expression: Expression{
+									Value: `"span content"`,
+									Range: Range{
+										From: Position{
+											Index: 27,
+											Line:  3,
+											Col:   6,
+										},
+										To: Position{
+											Index: 41,
+											Line:  3,
+											Col:   20,
+										},
+									},
+								},
+							},
+							Whitespace{Value: "\n"},
+						},
+					},
+					Whitespace{Value: "\n"},
+				},
+				Else: []Node{},
+			},
+		},
+		{
+			name: "if: else, without spaces",
+			input: `{%if p.A%}
+	{%= "A" %}
+{%else%}
+	{%= "B" %}
+{%endif%}`,
+			expected: IfExpression{
+				Expression: Expression{
+					Value: `p.A`,
+					Range: Range{
+						From: Position{
+							Index: 5,
+							Line:  1,
+							Col:   5,
+						},
+						To: Position{
+							Index: 8,
+							Line:  1,
+							Col:   8,
+						},
+					},
+				},
+				Then: []Node{
+					Whitespace{Value: "\t"},
+					StringExpression{
+						Expression: Expression{
+							Value: `"A"`,
+							Range: Range{
+								From: Position{
+									Index: 16,
+									Line:  2,
+									Col:   5,
+								},
+								To: Position{
+									Index: 19,
+									Line:  2,
+									Col:   8,
+								},
+							},
+						},
+					},
+					Whitespace{Value: "\n"},
+				},
+				Else: []Node{
+					Whitespace{Value: "\n\t"},
+					StringExpression{
+						Expression: Expression{
+							Value: `"B"`,
+							Range: Range{
+								From: Position{
+									Index: 37,
+									Line:  4,
+									Col:   5,
+								},
+								To: Position{
+									Index: 40,
+									Line:  4,
+									Col:   8,
+								},
+							},
+						},
+					},
+					Whitespace{Value: "\n"},
+				},
+			},
+		},
+		{
 			name: "if: nested",
 			input: `{% if p.A %}
 					{% if p.B %}

--- a/parser/importparser_test.go
+++ b/parser/importparser_test.go
@@ -55,6 +55,27 @@ func TestImportParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "import: no spaces",
+			input: `{%import "github.com/a-h/something"%}`,
+			expected: Import{
+				Expression: Expression{
+					Value: `"github.com/a-h/something"`,
+					Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   9,
+						},
+						To: Position{
+							Index: 35,
+							Line:  1,
+							Col:   35,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/parser/packageparser.go
+++ b/parser/packageparser.go
@@ -14,17 +14,18 @@ func newPackageParser() packageParser {
 type packageParser struct {
 }
 
+var packageExpressionStartParser = createStartParser("package")
+
 func (p packageParser) Parse(pi parse.Input) parse.Result {
 	// Check the prefix first.
-	packageStmtPrefix := "package "
-	prefixResult := parse.String("{% " + packageStmtPrefix)(pi)
+	prefixResult := packageExpressionStartParser(pi)
 	if !prefixResult.Success {
 		return prefixResult
 	}
 
 	// Once we have the prefix, we must have an expression and tag end on the same line.
 	from := NewPositionFromInput(pi)
-	pr := parse.StringUntil(parse.Or(newLine, tagEnd))(pi)
+	pr := parse.StringUntil(parse.Or(newLine, expressionEnd))(pi)
 	if pr.Error != nil && pr.Error != io.EOF {
 		return pr
 	}
@@ -40,7 +41,7 @@ func (p packageParser) Parse(pi parse.Input) parse.Result {
 	}
 
 	// Eat the tag end.
-	if te := tagEnd(pi); !te.Success {
+	if te := expressionEnd(pi); !te.Success {
 		return parse.Failure("packageParser", newParseError("package literal not terminated", from, NewPositionFromInput(pi)))
 	}
 

--- a/parser/packageparser_test.go
+++ b/parser/packageparser_test.go
@@ -91,6 +91,27 @@ func TestPackageParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "package: no spaces",
+			input: `{%package parser%}`,
+			expected: Package{
+				Expression: Expression{
+					Value: "parser",
+					Range: Range{
+						From: Position{
+							Index: 10,
+							Line:  1,
+							Col:   10,
+						},
+						To: Position{
+							Index: 16,
+							Line:  1,
+							Col:   16,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,7 +9,30 @@ import (
 )
 
 // Constants.
-var tagEnd = parse.String(" %}")
+// %}
+var expressionEnd = parse.Or(parse.String(" %}"), parse.String("%}"))
+
+// ) %}
+var expressionFuncEnd = parse.All(asNil, parse.Rune(')'), expressionEnd)
+
+func asNil(inputs []interface{}) (interface{}, bool) {
+	return nil, true
+}
+
+// create a parser for `{% name`
+func createStartParser(name string) parse.Function {
+	return parse.Or(parse.String("{% "+name+" "), parse.String("{%"+name+" "))
+}
+
+// create a parser for `{% name %}`
+func createEndParser(name string) parse.Function {
+	return parse.All(asNil,
+		parse.String("{%"),
+		parse.Optional(asNil, parse.Rune(' ')),
+		parse.String(name),
+		expressionEnd)
+}
+
 var newLine = parse.Or(parse.String("\r\n"), parse.Rune('\n'))
 
 // Whitespace.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -95,7 +95,7 @@ func (p templateParser) Parse(pi parse.Input) parse.Result {
 	return parse.Success("templ", r, nil)
 }
 
-var endTemplateParser = parse.String("{% endtempl %}")
+var endTemplateParser = createEndParser("endtempl")
 
 // Parse error.
 func newParseError(msg string, from Position, to Position) ParseError {

--- a/parser/scripttemplateparser_test.go
+++ b/parser/scripttemplateparser_test.go
@@ -51,6 +51,43 @@ func TestScriptTemplateParser(t *testing.T) {
 			},
 		},
 		{
+			name: "script: no spaces",
+			input: `{%script Name()%}
+{% endscript %}`,
+			expected: ScriptTemplate{
+				Name: Expression{
+					Value: "Name",
+					Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   9,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   13,
+						},
+					},
+				},
+				Parameters: Expression{
+					Value: "",
+					Range: Range{
+						From: Position{
+							Index: 14,
+							Line:  1,
+							Col:   14,
+						},
+						To: Position{
+							Index: 14,
+							Line:  1,
+							Col:   14,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "script: containing a JS variable",
 			input: `{% script Name() %}
 var x = "x";

--- a/parser/stringexpressionparser_test.go
+++ b/parser/stringexpressionparser_test.go
@@ -35,6 +35,28 @@ func TestStringExpressionParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "no spaces",
+			input: `{%="this"%}`,
+			expected: StringExpression{
+				Expression: Expression{
+					Value: `"this"`,
+					Range: Range{
+						From: Position{
+							Index: 3,
+							Line:  1,
+							Col:   3,
+						},
+						To: Position{
+
+							Index: 9,
+							Line:  1,
+							Col:   9,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/parser/switchexpressionparser_test.go
+++ b/parser/switchexpressionparser_test.go
@@ -170,6 +170,55 @@ func TestSwitchExpressionParser(t *testing.T) {
 			},
 		},
 		{
+			name: "switch: can be parsed without spaces",
+			input: `{%switch "stringy"%}
+{%case "stringy"%}
+	stringy
+{%endcase%}
+{%default%}
+	default
+{%enddefault%}
+{%endswitch%}`,
+			expected: SwitchExpression{
+				Expression: Expression{
+					Value: `"stringy"`,
+					Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   9,
+						},
+						To: Position{
+							Index: 18,
+							Line:  1,
+							Col:   18,
+						},
+					},
+				},
+				Cases: []CaseExpression{
+					{
+						Expression: Expression{
+							Value: `"stringy"`,
+							Range: Range{
+								From: Position{
+									Index: 28,
+									Line:  2,
+									Col:   7,
+								},
+								To: Position{
+									Index: 37,
+									Line:  2,
+									Col:   16,
+								},
+							},
+						},
+						Children: []Node{Text{Value: "stringy\n"}},
+					},
+				},
+				Default: []Node{Whitespace{Value: "\n\t"}, Text{Value: "default\n"}},
+			},
+		},
+		{
 			name: "switch: two cases",
 			input: `{% switch "stringy" %}
 {% case "stringy" %}

--- a/parser/templateparser.go
+++ b/parser/templateparser.go
@@ -28,12 +28,13 @@ var templateNameParser = parse.All(parse.WithStringConcatCombiner,
 type templateExpressionParser struct {
 }
 
+var templateExpressionStartParser = createStartParser("templ")
+
 func (p templateExpressionParser) Parse(pi parse.Input) parse.Result {
 	var r templateExpression
 
 	// Check the prefix first.
-	templPrefix := "templ "
-	prefixResult := parse.String("{% " + templPrefix)(pi)
+	prefixResult := templateExpressionStartParser(pi)
 	if !prefixResult.Success {
 		return prefixResult
 	}
@@ -74,8 +75,8 @@ func (p templateExpressionParser) Parse(pi parse.Input) parse.Result {
 
 	// Eat ") %}".
 	from = NewPositionFromInput(pi)
-	if lb := parse.String(") %}")(pi); !lb.Success {
-		return parse.Failure("templateExpressionParser", newParseError("template expression: unterminated (missing ' %}')", from, NewPositionFromInput(pi)))
+	if lb := expressionFuncEnd(pi); !lb.Success {
+		return parse.Failure("templateExpressionParser", newParseError("template expression: unterminated (missing ') %}')", from, NewPositionFromInput(pi)))
 	}
 
 	// Expect a newline.

--- a/parser/templateparser_test.go
+++ b/parser/templateparser_test.go
@@ -52,6 +52,44 @@ func TestTemplateParser(t *testing.T) {
 			},
 		},
 		{
+			name: "template: no spaces",
+			input: `{%templ Name()%}
+{% endtempl %}`,
+			expected: HTMLTemplate{
+				Name: Expression{
+					Value: "Name",
+					Range: Range{
+						From: Position{
+							Index: 8,
+							Line:  1,
+							Col:   8,
+						},
+						To: Position{
+							Index: 11,
+							Line:  1,
+							Col:   11,
+						},
+					},
+				},
+				Parameters: Expression{
+					Value: "",
+					Range: Range{
+						From: Position{
+							Index: 13,
+							Line:  1,
+							Col:   13,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   13,
+						},
+					},
+				},
+				Children: []Node{},
+			},
+		},
+		{
 			name: "template: single parameter",
 			input: `{% templ Name(p Parameter) %}
 {% endtempl %}`,

--- a/parser/textparser.go
+++ b/parser/textparser.go
@@ -14,14 +14,13 @@ func newTextParser() textParser {
 type textParser struct {
 }
 
+var tagOrTempl = parse.Or(parse.Rune('<'), parse.String("{%"))
+
 func (p textParser) Parse(pi parse.Input) parse.Result {
 	from := NewPositionFromInput(pi)
 
 	// Read until a tag or templ expression opens.
-	tagOpen := parse.Rune('<')
-	templOpen := parse.String("{%")
-
-	dtr := parse.StringUntil(parse.Or(tagOpen, templOpen))(pi)
+	dtr := parse.StringUntil(tagOrTempl)(pi)
 	if dtr.Error != nil {
 		if errors.Is(dtr.Error, io.EOF) {
 			return parse.Failure("textParser", newParseError("textParser: unterminated text, expected tag open or templ expression open statement", from, NewPositionFromInput(pi)))


### PR DESCRIPTION
The current behaviour enforces spaces, so that expressions like `{%endtempl %}`, `{% endtempl%}` and `{%endtempl%}` are not valid. This can be annoying since if you only miss a space, the template won't compile.

This change updates the template handling to ignore missed spaces, and `templ fmt` reformats them to include the spaces, i.e. goes from `{%endtempl%}` to `{% endtempl %}`.