### PR TITLE
feat(fmt): allow formatting from stdin

### DIFF
--- a/cmd/templ/fmtcmd/main.go
+++ b/cmd/templ/fmtcmd/main.go
@@ -3,6 +3,8 @@ package fmtcmd
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/a-h/templ/cmd/templ/processor"
@@ -14,6 +16,26 @@ import (
 const workerCount = 4
 
 func Run(args []string) (err error) {
+	if len(args) > 0 {
+		return formatDir(args[0])
+	}
+	return formatStdin()
+}
+
+func formatStdin() (err error) {
+	bytes, _ := ioutil.ReadAll(os.Stdin)
+	t, err := parser.ParseString(string(bytes))
+	if err != nil {
+		return fmt.Errorf("parsing error: %w", err)
+	}
+	err = t.Write(os.Stdout)
+	if err != nil {
+		return fmt.Errorf("formatting error: %w", err)
+	}
+	return nil
+}
+
+func formatDir(dir string) (err error) {
 	start := time.Now()
 	results := make(chan processor.Result)
 	go processor.Process(".", format, workerCount, results)


### PR DESCRIPTION
### Problem:

I can't format individual files. I want to plug `templ fmt` into https://github.com/mhartington/formatter.nvim

When `gofmt` isn't called with a path it reads from stdin.

### Solution:

When `fmt` is called with no parameters it reads from stdin, allowing you to do stuff like: `cat template.templ | templ fmt` which will print out the formatted template.

This breaks what fmt does currently, requring you to provide a directory for usual formatting, e.g. `templ fmt .`