### PR TITLE
fix: don't self-close empty script tags

### DIFF
--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -487,7 +487,7 @@ func (e RawElement) Write(w io.Writer, indent int) error {
 			return err
 		}
 	}
-	if _, err := w.Write([]byte("/>")); err != nil {
+	if _, err := w.Write([]byte(">")); err != nil {
 		return err
 	}
 	// Contents.

--- a/parser/v2/types_test.go
+++ b/parser/v2/types_test.go
@@ -63,6 +63,25 @@ templ input(value, validation string) {
 `,
 		},
 		{
+			name: "script tags are not converted to self-closing elements",
+			input: ` // first line removed to make indentation clear in Go code
+package test
+
+templ input(value, validation string) {
+	<script src="https://example.com/myscript.js"></script>
+}
+
+`,
+			expected: `// first line removed to make indentation clear in Go code
+package test
+
+templ input(value, validation string) {
+	<script src="https://example.com/myscript.js"></script>
+}
+
+`,
+		},
+		{
 			name: "empty elements stay on the same line",
 			input: ` // first line removed to make indentation clear in Go code
 package test


### PR DESCRIPTION
Hi, I encountered a bug in v2 of templ where `<script src="..."></script>` elements are being self-closed by the formatter and end up looking like this:

```html
<script src="..."/></script>
```

I added a reproducing test case and fixed it, but I'm not sure if my implementation change makes sense.

Thanks for the review and thanks for making templ, I love the concept!