### PR TITLE
fix: regex syntax incorrect causing hyphenated classes to be sanitized.

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -149,7 +149,7 @@ func (classes CSSClasses) String() string {
 	return sb.String()
 }
 
-var safeClassName = regexp.MustCompile(`^-?[_a-zA-Z]+[_-a-zA-Z0-9]*$`)
+var safeClassName = regexp.MustCompile(`^-?[_a-zA-Z]+[-_a-zA-Z0-9]*$`)
 
 const fallbackClassName = ConstantCSSClass("--templ-css-class-safe-name")
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -200,6 +200,14 @@ func TestClassSanitization(t *testing.T) {
 			expected: `safe`,
 		},
 		{
+			input:    `safe-name`,
+			expected: "safe-name",
+		},
+		{
+			input:    `safe_name`,
+			expected: "safe_name",
+		},
+		{
 			input:    `!unsafe`,
 			expected: "--templ-css-class-safe-name",
 		},


### PR DESCRIPTION
When including a hyphen in a regex it must come first: [-A-Z]