### PR TITLE
Block element fix

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -608,6 +608,9 @@ func (g *generator) writeBlockTemplElementExpression(indentLevel int, n parser.T
 		return err
 	}
 	indentLevel++
+	if _, err = g.w.WriteIndent(indentLevel, "templBuffer := w.(*bytes.Buffer)\n"); err != nil {
+		return err
+	}
 	if err = g.writeNodes(indentLevel, n, stripLeadingAndTrailingWhitespace(n.Children)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Very niche issue that only manifests if you're doing some funky stuff with templ.

Template:

The raw function captures the rendered children and escapes (for code snippets).
```
@shared.Raw() {
	<div>Joe</div>
}
```

Previous behaviour:

Notice that the closured template is writing to `templBuffer`, rather than `w`.

In most normal cases this is fine as the writer is the same, however in my case I have a custom component which handles the rendereing.
```go
			// TemplElement
			var_20 := templ.ComponentFunc(func(ctx context.Context, w io.Writer) (err error) {
				// Element (standard)
				_, err = templBuffer.WriteString("<div>")
                                ....
				return err
			})
			err = shared.Raw().Render(templ.WithChildren(ctx, var_20), templBuffer)

```

New behaviour:

Now it converts `w` to a `templBuffer`. `w` cannot be assumed to be a `*bytes.Buffer` either, as in `Raw` I could have used something other than a bytes.Buffer.

```go
			// TemplElement
			var_20 := templ.ComponentFunc(func(ctx context.Context, w io.Writer) (err error) {
				templBuffer, templIsBuffer := w.(*bytes.Buffer)
				if !templIsBuffer {
					templBuffer = templ.GetBuffer()
					defer templ.ReleaseBuffer(templBuffer)
				}

				// Element (standard)
				_, err = templBuffer.WriteString("<div>")
				...
				templBuffer, templIsBuffer := w.(*bytes.Buffer)
				if !templIsBuffer {
					templBuffer = templ.GetBuffer()
					defer templ.ReleaseBuffer(templBuffer)
				}
				return err
			})
			err = shared.Raw().Render(templ.WithChildren(ctx, var_20), templBuffer)

```