### PR TITLE
feat: allow preceeding dash in css ident token

### DIFF
--- a/parser/v2/cssparser.go
+++ b/parser/v2/cssparser.go
@@ -126,7 +126,7 @@ var cssExpressionParser = parse.Func(func(pi *parse.Input) (r cssExpression, ok 
 })
 
 // CSS property name parser.
-var cssPropertyNameFirst = "abcdefghijklmnopqrstuvwxyz"
+var cssPropertyNameFirst = "abcdefghijklmnopqrstuvwxyz-"
 var cssPropertyNameSubsequent = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
 var cssPropertyNameParser = parse.Func(func(in *parse.Input) (name string, ok bool, err error) {
 	start := in.Position()

--- a/parser/v2/cssparser_test.go
+++ b/parser/v2/cssparser_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExpressionCSSPropertyParser(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		input    string
 		expected ExpressionCSSProperty
@@ -81,7 +81,7 @@ func TestExpressionCSSPropertyParser(t *testing.T) {
 }
 
 func TestConstantCSSPropertyParser(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		input    string
 		expected ConstantCSSProperty
@@ -91,6 +91,14 @@ func TestConstantCSSPropertyParser(t *testing.T) {
 			input: `background-color: #ffffff;`,
 			expected: ConstantCSSProperty{
 				Name:  "background-color",
+				Value: "#ffffff",
+			},
+		},
+		{
+			name:  "css: single constant webkit property",
+			input: `-webkit-text-stroke-color: #ffffff;`,
+			expected: ConstantCSSProperty{
+				Name:  "-webkit-text-stroke-color",
 				Value: "#ffffff",
 			},
 		},
@@ -114,7 +122,7 @@ func TestConstantCSSPropertyParser(t *testing.T) {
 }
 
 func TestCSSParser(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		input    string
 		expected CSSTemplate

--- a/safehtml/style.go
+++ b/safehtml/style.go
@@ -29,7 +29,7 @@ func SanitizeCSS(property, value string) (string, string) {
 // identifierPattern matches a subset of valid <ident-token> values defined in
 // https://www.w3.org/TR/css-syntax-3/#ident-token-diagram. This pattern matches all generic family name
 // keywords defined in https://drafts.csswg.org/css-fonts-3/#family-name-value.
-var identifierPattern = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z]+$`)
+var identifierPattern = regexp.MustCompile(`^[-a-zA-Z]+$`)
 
 var cssPropertyNameToValueSanitizer = map[string]func(string) string{
 	"background-image":    sanitizeBackgroundImage,
@@ -124,14 +124,14 @@ const InnocuousPropertyValue = "zTemplUnsafeCSSPropertyValue"
 // Specifically, it matches string where every '*' or '/' is followed by end-of-text or a safe rune
 // (i.e. alphanumberics or runes in the set [+-.!#%_ \t]). This regex ensures that the following
 // are disallowed:
-//    * "/*" and "*/", which are CSS comment markers.
-//    * "//", even though this is not a comment marker in the CSS specification. Disallowing
-//      this string minimizes the chance that browser peculiarities or parsing bugs will allow
-//      sanitization to be bypassed.
-//    * '(' and ')', which can be used to call functions.
-//    * ',', since it can be used to inject extra values into a property.
-//    * Runes which could be matched on CSS error recovery of a previously malformed token, such as '@'
-//      and ':'. See http://www.w3.org/TR/css3-syntax/#error-handling.
+//   - "/*" and "*/", which are CSS comment markers.
+//   - "//", even though this is not a comment marker in the CSS specification. Disallowing
+//     this string minimizes the chance that browser peculiarities or parsing bugs will allow
+//     sanitization to be bypassed.
+//   - '(' and ')', which can be used to call functions.
+//   - ',', since it can be used to inject extra values into a property.
+//   - Runes which could be matched on CSS error recovery of a previously malformed token, such as '@'
+//     and ':'. See http://www.w3.org/TR/css3-syntax/#error-handling.
 var safeRegularPropertyValuePattern = regexp.MustCompile(`^(?:[*/]?(?:[0-9a-zA-Z+-.!#%_ \t]|$))*$`)
 
 // safeEnumPropertyValuePattern matches strings that are safe to use as enumerated property values.

--- a/safehtml/style_test.go
+++ b/safehtml/style_test.go
@@ -3,7 +3,7 @@ package safehtml
 import "testing"
 
 func TestSanitizeCSS(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name             string
 		inputProperty    string
 		expectedProperty string
@@ -198,6 +198,13 @@ func TestSanitizeCSS(t *testing.T) {
 			expectedProperty: "background-image",
 			inputValue:       `url("http://safe.example.com/img.png"), url("https://safe.example.com/other.png")`,
 			expectedValue:    `url("http://safe.example.com/img.png"), url("https://safe.example.com/other.png")`,
+		},
+		{
+			name:             "-webkit-text-stroke-color safe webkit",
+			inputProperty:    "-webkit-text-stroke-color",
+			expectedProperty: "-webkit-text-stroke-color",
+			inputValue:       `#000`,
+			expectedValue:    `#000`,
 		},
 		{
 			name:             "escape attempt property name",


### PR DESCRIPTION
https://www.w3.org/TR/css-syntax-3/#ident-token-diagram