### PR TITLE
feat: format generated code with gofmt

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1183,7 +1183,7 @@ func (g *generator) writeElementAttributes(indentLevel int, name string, attrs [
 }
 
 func (g *generator) writeRawElement(indentLevel int, n parser.RawElement) (err error) {
-	if _, err = g.w.WriteIndent(0, "// RawElement\n"); err != nil {
+	if _, err = g.w.WriteIndent(indentLevel, "// RawElement\n"); err != nil {
 		return err
 	}
 	if len(n.Attributes) == 0 {
@@ -1214,7 +1214,7 @@ func (g *generator) writeRawElement(indentLevel int, n parser.RawElement) (err e
 		}
 	}
 	// Contents.
-	if err = g.writeText(0, parser.Text{Value: n.Contents}); err != nil {
+	if err = g.writeText(indentLevel, parser.Text{Value: n.Contents}); err != nil {
 		return err
 	}
 	// </div>

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -144,7 +144,7 @@ func (g *generator) writeTemplateNodes() error {
 				return err
 			}
 		case parser.HTMLTemplate:
-			if err := g.writeTemplate(n); err != nil {
+			if err := g.writeTemplate(i, n); err != nil {
 				return err
 			}
 		case parser.CSSTemplate:
@@ -280,7 +280,7 @@ func (g *generator) writeTemplBuffer(indentLevel int) (err error) {
 	return
 }
 
-func (g *generator) writeTemplate(t parser.HTMLTemplate) error {
+func (g *generator) writeTemplate(nodeIdx int, t parser.HTMLTemplate) error {
 	var r parser.Range
 	var err error
 	var indentLevel int
@@ -368,7 +368,15 @@ func (g *generator) writeTemplate(t parser.HTMLTemplate) error {
 	}
 	indentLevel--
 	// }
-	if _, err = g.w.WriteIndent(indentLevel, "}\n\n"); err != nil {
+
+	// Note: gofmt wants to remove a single empty line at the end of a file
+	// so we have to make sure we don't output one if this is the last node.
+	closingBrace := "}\n\n"
+	if nodeIdx+1 >= len(g.tf.Nodes) {
+		closingBrace = "}\n"
+	}
+
+	if _, err = g.w.WriteIndent(indentLevel, closingBrace); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Hi,

first, thank you for templ, it's a cool project which I'm using more and more.

One thing I would like is to have the generated code properly formatted with gofmt. In my projects I always have a CI check that runs `gofmt -d .` to verify all my Go code is properly formatted but as of right now the code produced by templ is not properly formatted.

It's small stuff, for example taking the templates under `generator` and running `gofmt -d .`, we can see:

* incorrect indentation

```diff
-// Text
-var_4 := `
+               // Text
+               var_4 := `
         $("div").marquee();
         function test() {
               window.open("https://example.com")
         }
       `
-_, err = templBuffer.WriteString(var_4)
-if err != nil {
-       return err
-}
+               _, err = templBuffer.WriteString(var_4)
+               if err != nil {
+                       return err
+               }
```

* wrong comment indentation on switch cases, empty last line at the end

```diff
diff test-switch/template_templ.go.orig test-switch/template_templ.go
--- test-switch/template_templ.go.orig
+++ test-switch/template_templ.go
@@ -24,13 +24,13 @@
                ctx = templ.ClearChildren(ctx)
                // Switch
                switch input {
-               case "a":                       // StringExpression
+               case "a": // StringExpression
                        var var_2 string = "it was 'a'"
                        _, err = templBuffer.WriteString(templ.EscapeString(var_2))
                        if err != nil {
                                return err
                        }
-               default:                        // StringExpression
+               default: // StringExpression
                        var var_3 string = "it was something else"
                        _, err = templBuffer.WriteString(templ.EscapeString(var_3))
                        if err != nil {
@@ -43,4 +43,3 @@
                return err
        })
 }
-
```

* misalignment when creating a struct

```diff
 func withoutParameters() templ.ComponentScript {
        return templ.ComponentScript{
-               Name: `__templ_withoutParameters_6bbf`,
+               Name:     `__templ_withoutParameters_6bbf`,
                Function: `function __templ_withoutParameters_6bbf(){alert("hello");}`,
-               Call: templ.SafeScript(`__templ_withoutParameters_6bbf`, ),
+               Call:     templ.SafeScript(`__templ_withoutParameters_6bbf`),
        }
 }
```

* too many spaces when creating a map

```diff
                ctx = templ.ClearChildren(ctx)
                // Element (standard)
                // Element CSS
-               var var_7 = []any{map[string]bool{ "a": true, "b": false, "c": true }}
+               var var_7 = []any{map[string]bool{"a": true, "b": false, "c": true}}
                err = templ.RenderCSSItems(ctx, templBuffer, var_7...)
                if err != nil {
                        return err
```

That's all I've seen but it's possible there's more.

There's two parts in this PR:
* the 2 commits prefixed with `generator:` which was an attempt to make the generator output correct code. I didn't fix everything in these commits.
* the last commit prefixed with `generatecmd:` which simply takes the output of the generator and runs `format.Source` on it. This function is included in the stdlib and is what `gofmt` uses under the hood.

So, I think there's 2 options:
* either try to make the generator output properly formatted code
* or let the Go stdlib do the heavy lifting

One thing to note is that the formatting might change across Go version changes, so building templ with a new Go version could also change the formatting, this could be an argument against using `format.Source`.

I would love to have your input on this !