### PR TITLE
fmtcmd: actually use the dir parameter

### DIFF
--- a/cmd/templ/fmtcmd/main.go
+++ b/cmd/templ/fmtcmd/main.go
@@ -42,7 +42,7 @@ func formatStdin() (err error) {
 func formatDir(dir string) (err error) {
 	start := time.Now()
 	results := make(chan processor.Result)
-	go processor.Process(".", format, workerCount, results)
+	go processor.Process(dir, format, workerCount, results)
 	var successCount, errorCount int
 	for r := range results {
 		if r.Error != nil {


### PR DESCRIPTION
Currently `templ fmt /my/directory` is broken, it always formats the current directory.