### PR TITLE
docs: link to tree-sitter-templ for Neovim

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -11,6 +11,8 @@ There's a VS Code extension, just make sure you've already installed templ and t
 
 A vim / neovim plugin is available from https://github.com/Joe-Davidson1802/templ.vim which adds syntax highlighting.
 
+For neovim you can also use [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for syntax highlighting with the custom parser [tree-sitter-templ](https://github.com/vrischmann/tree-sitter-templ).
+
 To enable the built-in Language Server support of Neovim 5.x add the following code to your `.vimrc` prior to calling `setup` on the language servers, e.g.:
 
 ```lua


### PR DESCRIPTION
Hi,

I've been working on a tree-sitter parser lately for Templ (see [tree-sitter-templ](https://github.com/vrischmann/tree-sitter-templ)), which works quite well right now. Here are some screenshots

![image](https://github.com/a-h/templ/assets/1916079/235044b5-0e17-4ebc-b18b-6628cfac8182)
![image](https://github.com/a-h/templ/assets/1916079/b2e1eb1c-ecbb-4e56-bf25-488e76bdcd4f)

One area where it's quite good compared to templ.vim is highlighting Go code because I was able to reuse the Go tree-sitter [parser](https://github.com/tree-sitter/tree-sitter-go) for some things. 
Some other things don't work well yet (conditional attributes for example).

With this PR I'm proposing adding a link to [tree-sitter-templ](https://github.com/vrischmann/tree-sitter-templ) in the documentation page "IDE support", I believe it could be useful to others.