### PR TITLE
fix: replace new lines in constant attributes with escaped new lines

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -937,6 +937,7 @@ func (g *generator) writeBoolConstantAttribute(indentLevel int, attr parser.Bool
 func (g *generator) writeConstantAttribute(indentLevel int, attr parser.ConstantAttribute) (err error) {
 	name := html.EscapeString(attr.Name)
 	value := html.EscapeString(attr.Value)
+	value = strings.ReplaceAll(value, "\n", "\\n")
 	if _, err = g.w.WriteStringLiteral(indentLevel, fmt.Sprintf(` %s=\"%s\"`, name, value)); err != nil {
 		return err
 	}

--- a/generator/test-element-attributes/expected.html
+++ b/generator/test-element-attributes/expected.html
@@ -13,4 +13,8 @@
 <div style="width: 100;" class="unimportant_900a">
   Else
  </div>
+<div data-script="on click
+                do something
+             end">
+</div>
 

--- a/generator/test-element-attributes/template.templ
+++ b/generator/test-element-attributes/template.templ
@@ -26,5 +26,8 @@ templ render(p person) {
 			class={ unimportant }
 		}
 		>Else</div>
+	<div data-script="on click
+                do something
+             end"></div>
 }
 

--- a/generator/test-element-attributes/template_templ.go
+++ b/generator/test-element-attributes/template_templ.go
@@ -165,7 +165,7 @@ func render(p person) templ.Component {
 		if err != nil {
 			return err
 		}
-		_, err = templBuffer.WriteString("</div>")
+		_, err = templBuffer.WriteString("</div><div data-script=\"on click\n                do something\n             end\"></div>")
 		if err != nil {
 			return err
 		}

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -267,15 +267,27 @@ if test {
 			},
 		},
 		{
+			name: "multiline attribute",
+			input: ` data-script="on click
+                do something
+             end"
+`,
+			parser: StripType(constantAttributeParser),
+			expected: ConstantAttribute{
+				Name:  "data-script",
+				Value: "on click\n                do something\n             end",
+			},
+		},
+		{
 			name:   "bool constant attribute",
 			input:  `<div data>`,
 			parser: StripType(elementOpenTagParser),
 			expected: elementOpenTag{
-				Name:       "div",
+				Name: "div",
 				Attributes: []Attribute{
 					BoolConstantAttribute{
 						Name: "data",
-					},	
+					},
 				},
 			},
 		},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -308,7 +308,8 @@ type Element struct {
 }
 
 var voidElements = map[string]struct{}{
-	"area": {}, "base": {}, "br": {}, "col": {}, "command": {}, "embed": {}, "hr": {}, "img": {}, "input": {}, "keygen": {}, "link": {}, "meta": {}, "param": {}, "source": {}, "track": {}, "wbr": {}}
+	"area": {}, "base": {}, "br": {}, "col": {}, "command": {}, "embed": {}, "hr": {}, "img": {}, "input": {}, "keygen": {}, "link": {}, "meta": {}, "param": {}, "source": {}, "track": {}, "wbr": {},
+}
 
 // https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
 func (e Element) IsVoidElement() bool {
@@ -538,6 +539,7 @@ func (bca BoolConstantAttribute) IsMultilineAttr() bool { return false }
 func (bca BoolConstantAttribute) String() string {
 	return bca.Name
 }
+
 func (bca BoolConstantAttribute) Write(w io.Writer, indent int) error {
 	return writeIndent(w, indent, bca.String())
 }
@@ -552,6 +554,7 @@ func (ca ConstantAttribute) IsMultilineAttr() bool { return false }
 func (ca ConstantAttribute) String() string {
 	return ca.Name + `="` + html.EscapeString(ca.Value) + `"`
 }
+
 func (ca ConstantAttribute) Write(w io.Writer, indent int) error {
 	return writeIndent(w, indent, ca.String())
 }
@@ -566,6 +569,7 @@ func (ea BoolExpressionAttribute) IsMultilineAttr() bool { return false }
 func (ea BoolExpressionAttribute) String() string {
 	return ea.Name + `?={ ` + ea.Expression.Value + ` }`
 }
+
 func (ea BoolExpressionAttribute) Write(w io.Writer, indent int) error {
 	return writeIndent(w, indent, ea.String())
 }
@@ -580,6 +584,7 @@ func (ea ExpressionAttribute) IsMultilineAttr() bool { return false }
 func (ea ExpressionAttribute) String() string {
 	return ea.Name + `={ ` + ea.Expression.Value + ` }`
 }
+
 func (ea ExpressionAttribute) Write(w io.Writer, indent int) error {
 	return writeIndent(w, indent, ea.String())
 }


### PR DESCRIPTION
Fixes #115 