### PR TITLE
fix: migrate anchor tag snippet to 2.0 syntax

### DIFF
--- a/cmd/templ/lspcmd/proxy/snippets.go
+++ b/cmd/templ/lspcmd/proxy/snippets.go
@@ -13,7 +13,7 @@ var htmlSnippets = []lsp.CompletionItem{
 	},
 	{
 		Label:            "a",
-		InsertText:       `a href="${1:}">{%= ${2:""} %}</a>`,
+		InsertText:       `a href="${1:}">${2:}</a>`,
 		Kind:             lsp.CompletionItemKind(lsp.CompletionItemKindSnippet),
 		InsertTextFormat: lsp.InsertTextFormatSnippet,
 	},


### PR DESCRIPTION
migrate `a` snippet from the old syntax