### PR TITLE
Return error when generation fails

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -121,7 +121,7 @@ func runCmd(ctx context.Context, args Arguments) (err error) {
 			if errors.Is(errs[0], context.Canceled) {
 				return errs[0]
 			}
-			fmt.Printf("Error processing path: %v\n", errors.Join(errs...))
+			return fmt.Errorf("Error processing path: %w\n", errors.Join(errs...))
 		}
 		if changesFound > 0 {
 			fmt.Printf("Generated code for %d templates with %d errors in %s\n", changesFound, len(errs), time.Since(start))

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -121,7 +121,10 @@ func runCmd(ctx context.Context, args Arguments) (err error) {
 			if errors.Is(errs[0], context.Canceled) {
 				return errs[0]
 			}
-			return fmt.Errorf("Error processing path: %w\n", errors.Join(errs...))
+			if !args.Watch {
+				return fmt.Errorf("failed to process path: %v", errors.Join(errs...))
+			}
+			fmt.Printf("Error processing path: %v\n", errors.Join(errs...))
 		}
 		if changesFound > 0 {
 			fmt.Printf("Generated code for %d templates with %d errors in %s\n", changesFound, len(errs), time.Since(start))


### PR DESCRIPTION
This caught me by surprise when using `air` to auto-rebuild.

The `file.templ` was invalid and `templ generate` does not fail, it just prints the error. It caused the logical AND to succeed and rebuild while I kept working on the project and wondering why I'm not seeing my changes.

```toml
cmd = "templ generate && go build -o ./tmp/main ."
```

With this changes, it fails and the server dies, which is what I was expecting. 
Maybe it is just me, let me know what you think.

Cheers