### PR TITLE
chore: Use static distroless image

### DIFF
--- a/docs/docs/08-hosting-and-deployment/02-hosting-using-docker.md
+++ b/docs/docs/08-hosting-and-deployment/02-hosting-using-docker.md
@@ -25,7 +25,7 @@ COPY . /app
 RUN CGO_ENABLED=0 GOOS=linux go build -o /entrypoint
 
 # Deploy.
-FROM gcr.io/distroless/base-debian11 AS release-stage
+FROM gcr.io/distroless/static-debian11 AS release-stage
 WORKDIR /
 COPY --from=build-stage /entrypoint /entrypoint
 // highlight-next-line

--- a/examples/counter-basic/Dockerfile
+++ b/examples/counter-basic/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 RUN CGO_ENABLED=0 GOOS=linux go build -o /entrypoint
 
 # Deploy.
-FROM gcr.io/distroless/base-debian11 AS release-stage
+FROM gcr.io/distroless/static-debian11 AS release-stage
 WORKDIR /
 COPY --from=build-stage /entrypoint /entrypoint
 COPY --from=build-stage /app/assets /assets


### PR DESCRIPTION
Since CGO is not required for this example, we can use the distroless static-debian11 image. This reduces the size of the image by 18 MB. Although this is just an example, I figured it would be nice show the usage of this static image in the docs.

```
counter-basic-static latest  635b8094b79a   10 seconds ago   10.6MB
counter-basic        latest  047d3cd36484   2 minutes ago    28.6MB
```