### PR TITLE
docs: Add godoc badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![templ](https://github.com/a-h/templ/raw/main/templ.png)
 
 ## A HTML templating language for Go that has great developer tooling.
+[![Go Reference](https://pkg.go.dev/badge/github.com/a-h/templ.svg)](https://pkg.go.dev/github.com/a-h/templ)
 
 ![templ](https://user-images.githubusercontent.com/1029947/171962961-38aec64d-eac3-4166-8cb6-e7337c907bae.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 ![templ](https://github.com/a-h/templ/raw/main/templ.png)
 
 ## A HTML templating language for Go that has great developer tooling.
-[![Go Reference](https://pkg.go.dev/badge/github.com/a-h/templ.svg)](https://pkg.go.dev/github.com/a-h/templ)
 
 ![templ](https://user-images.githubusercontent.com/1029947/171962961-38aec64d-eac3-4166-8cb6-e7337c907bae.gif)
 
 ## Documentation
 
 See user documentation at https://templ.guide
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/a-h/templ.svg)](https://pkg.go.dev/github.com/a-h/templ)
 
 ## Tasks
 


### PR DESCRIPTION
I think it would be useful to have a godoc badge in the README for easy access to the package documentation. If approved, please move it to where ever you like. I just put it towards the top like most README's, although it could make sense to put it under the documentation part.

Badge created via https://pkg.go.dev/badge/.