### PR TITLE
fix: maintain whitespace around templated values

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -412,6 +412,14 @@ func stripNonCriticalElementWhitespace(input []parser.Node) (output []parser.Nod
 			output = append(output, curr)
 			continue
 		}
+		
+		_, prevIsStringExpr := prev.(parser.StringExpression)
+		_, nextIsStringExpr := next.(parser.StringExpression)
+		if prevIsStringExpr || nextIsStringExpr {
+			// Allow whitespace that comes before or after a template expression.
+			output = append(output, curr)
+			continue
+		}
 	}
 	return
 }

--- a/generator/test-text-whitespace/render_test.go
+++ b/generator/test-text-whitespace/render_test.go
@@ -35,6 +35,11 @@ func TestTextWhitespace(t *testing.T) {
 			input:    WhiteSpaceAroundValues(),
 			expected: WhiteSpaceAroundValuesExpected,
 		},
+		{
+			name:     "whitespace around templated values is maintained",
+			input:    WhiteSpaceAroundTemplatedValues("templ", "allows whitespace around templated values."),
+			expected: WhiteSpaceAroundTemplatedValuesExpected,
+		},
 	} {
 		w := new(strings.Builder)
 		err := test.input.Render(context.Background(), w)

--- a/generator/test-text-whitespace/template.templ
+++ b/generator/test-text-whitespace/template.templ
@@ -31,3 +31,9 @@ templ WhiteSpaceAroundValues() {
 }
 
 const WhiteSpaceAroundValuesExpected = `<p>templ allows strings to be included in sentences.</p>`
+
+const WhiteSpaceAroundTemplatedValuesExpected = `<div>templ allows whitespace around templated values.</div>`
+
+templ WhiteSpaceAroundTemplatedValues(prefix, statement string) {
+  <div>{prefix} {statement}</div>
+}

--- a/generator/test-text-whitespace/template_templ.go
+++ b/generator/test-text-whitespace/template_templ.go
@@ -209,3 +209,47 @@ func WhiteSpaceAroundValues() templ.Component {
 }
 
 const WhiteSpaceAroundValuesExpected = `<p>templ allows strings to be included in sentences.</p>`
+
+const WhiteSpaceAroundTemplatedValuesExpected = `<div>templ allows whitespace around templated values.</div>`
+
+func WhiteSpaceAroundTemplatedValues(prefix, statement string) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) (err error) {
+		templBuffer, templIsBuffer := w.(*bytes.Buffer)
+		if !templIsBuffer {
+			templBuffer = templ.GetBuffer()
+			defer templ.ReleaseBuffer(templBuffer)
+		}
+		ctx = templ.InitializeContext(ctx)
+		var_16 := templ.GetChildren(ctx)
+		if var_16 == nil {
+			var_16 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		_, err = templBuffer.WriteString("<div>")
+		if err != nil {
+			return err
+		}
+		var var_17 string = prefix
+		_, err = templBuffer.WriteString(templ.EscapeString(var_17))
+		if err != nil {
+			return err
+		}
+		_, err = templBuffer.WriteString(" ")
+		if err != nil {
+			return err
+		}
+		var var_18 string = statement
+		_, err = templBuffer.WriteString(templ.EscapeString(var_18))
+		if err != nil {
+			return err
+		}
+		_, err = templBuffer.WriteString("</div>")
+		if err != nil {
+			return err
+		}
+		if !templIsBuffer {
+			_, err = templBuffer.WriteTo(w)
+		}
+		return err
+	})
+}


### PR DESCRIPTION
I noticed while following the docs (specifically https://templ.guide/syntax-and-usage/expressions) that for the following template:
```
package main

templ greet(prefix string, p Person) {
  <div>{ prefix } { p.Name }{ exclamation }</div>
}
```
The whitespace between `{prefix}` and `{p.Name}` is not preserved.  This is an attempt to fix that.