### PR TITLE
docs: fix basic syntax example

### DIFF
--- a/docs/docs/03-syntax-and-usage/01-basic-syntax.md
+++ b/docs/docs/03-syntax-and-usage/01-basic-syntax.md
@@ -34,12 +34,15 @@ Outside of templ Components, templ files are ordinary Go code.
 ```templ name="header.templ"
 package main
 
+// Ordinary Go code that we can use in our Component.
 var greeting = "Welcome!"
 
+// templ Component
 templ headerTemplate(name string) {
   <header>
     <h1>{ name }</h1>
-    <h2>{ greeting }</h2>
+    <h2>"{ greeting }" comes from ordinary Go code</h2>
   </header>
 }
 ```
+


### PR DESCRIPTION
Hi, I believe this example should be Go code, not the templ code.