### PR TITLE
fix: --cmd breaking with >1 argument, kill child processes correctly

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -62,6 +62,7 @@ func Run(args Arguments) (err error) {
 		select {
 		case <-signalChan: // First signal, cancel context.
 			fmt.Println("\nCancelling...")
+			run.KillAll()
 			cancel()
 		case <-ctx.Done():
 		}

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -62,7 +62,10 @@ func Run(args Arguments) (err error) {
 		select {
 		case <-signalChan: // First signal, cancel context.
 			fmt.Println("\nCancelling...")
-			run.KillAll()
+			err = run.KillAll()
+			if err != nil {
+				fmt.Printf("Error killing command: %v\n", err)
+			}
 			cancel()
 		case <-ctx.Done():
 		}

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -134,11 +134,12 @@ func runCmd(ctx context.Context, args Arguments) (err error) {
 				if _, err := run.Run(ctx, args.Path, args.Command); err != nil {
 					fmt.Printf("Error starting command: %v\n", err)
 				}
-				// Send server-sent event.
-				if p != nil {
-					p.SendSSE("message", "reload")
-				}
 			}
+			// Send server-sent event.
+			if p != nil {
+				p.SendSSE("message", "reload")
+			}
+
 			if !firstRunComplete && p != nil {
 				go func() {
 					fmt.Printf("Proxying from %s to target: %s\n", p.URL, p.Target.String())

--- a/cmd/templ/generatecmd/run/run.go
+++ b/cmd/templ/generatecmd/run/run.go
@@ -42,16 +42,9 @@ func Run(ctx context.Context, workingDir, input string) (cmd *exec.Cmd, err erro
 	defer m.Unlock()
 	cmd, ok := running[input]
 	if ok {
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err = KillAll()
-			if err != nil {
-				return
-			}
-		}()
-		wg.Wait()
+		if err = KillAll(); err != nil {
+			return
+		}
 		delete(running, input)
 	}
 

--- a/cmd/templ/generatecmd/run/run.go
+++ b/cmd/templ/generatecmd/run/run.go
@@ -2,39 +2,62 @@ package run
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 var m = &sync.Mutex{}
 var running = map[string]*exec.Cmd{}
+
+func KillAll() {
+	m.Lock()
+	defer m.Unlock()
+	for _, cmd := range running {
+		if runtime.GOOS == "windows" {
+			kill := exec.Command("TASKKILL", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+			kill.Stderr = os.Stderr
+			kill.Stdout = os.Stdout
+			kill.Run()
+			continue
+		}
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	running = map[string]*exec.Cmd{}
+}
 
 func Run(ctx context.Context, workingDir, input string) (cmd *exec.Cmd, err error) {
 	m.Lock()
 	defer m.Unlock()
 	cmd, ok := running[input]
 	if ok {
-		if err = cmd.Process.Kill(); err != nil {
-			return nil, fmt.Errorf("failed to kill existing process: %w", err)
-		}
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			KillAll()
+		}()
+		wg.Wait()
 		delete(running, input)
 	}
 
-	parts := strings.SplitN(input, " ", 2)
+	parts := strings.Fields(input)
 	executable := parts[0]
 	args := []string{}
 	if len(parts) > 1 {
-		args = append(args, parts[1])
+		args = append(args, parts[1:]...)
 	}
 
-	cmd = exec.CommandContext(ctx, executable, args...)
+	cmd = exec.Command(executable, args...)
 	cmd.Env = os.Environ()
 	cmd.Dir = workingDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	running[input] = cmd
 	err = cmd.Start()
 	return

--- a/cmd/templ/generatecmd/run/run.go
+++ b/cmd/templ/generatecmd/run/run.go
@@ -46,7 +46,10 @@ func Run(ctx context.Context, workingDir, input string) (cmd *exec.Cmd, err erro
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			KillAll()
+			err = KillAll()
+			if err != nil {
+				return
+			}
 		}()
 		wg.Wait()
 		delete(running, input)


### PR DESCRIPTION
Fixes issue 4 in the #146 experience report.
Maybe add tests for the cli to prevent future issues.