### PR TITLE
doc: fix io.Writer examples

### DIFF
--- a/docs/docs/02-quick-start/02-creating-a-simple-templ-component.md
+++ b/docs/docs/02-quick-start/02-creating-a-simple-templ-component.md
@@ -79,6 +79,6 @@ go run *.go
 <div>Hello, John</div>
 ```
 
-Instead of passing `os.Stdout` to the component's render function, you can pass any type that implements the `io.Writer` interface. This includes files, HTTP requests, and HTTP responses.
+Instead of passing `os.Stdout` to the component's render function, you can pass any type that implements the `io.Writer` interface. This includes files, `bytes.Buffer`, and HTTP responses.
 
 In this way, templ can be used to generate HTML files that can be hosted as static content in an S3 bucket, Google Cloud Storage, or used to generate HTML that is fed into PDF conversion processes, or sent via email.


### PR DESCRIPTION
The `Write()` method of `http.Request` writes the request content into a specified `io.Writer`, instead of writing specified bytes into itself.