### PR TITLE
doc: add missing () in CSS component example

### DIFF
--- a/docs/docs/03-syntax-and-usage/09-css-style-management.md
+++ b/docs/docs/03-syntax-and-usage/09-css-style-management.md
@@ -147,8 +147,8 @@ CSS components can also be conditionally rendered.
 ```templ title="component.templ"
 package main
 
-var red = "#ff0000";
-var blue = "#0000ff";
+var red = "#ff0000"
+var blue = "#0000ff"
 
 css primaryClassName() {
 	background-color: #ffffff;
@@ -161,7 +161,7 @@ css className() {
 }
 
 templ button(text string, isPrimary bool) {
-	<button class={ "button", className, templ.KV(primaryClassName, isPrimary) }>{ text }</button>
+	<button class={ "button", className(), templ.KV(primaryClassName(), isPrimary) }>{ text }</button>
 }
 ```
 


### PR DESCRIPTION
- Add missing `()` for `css` components.
- Remove redundant trailing `;`.

According to the implementation of `RenderCSSItems()`, `className` still works without invocation, but the previous doc follows a theme that `()` is always good (unless the component is used in other clever ways). I think it's better to keep consistent here, or make it clear in the doc when a factory function is also OK.