### PR TITLE
feat: make templ fmt, format writen go code in templates

### DIFF
--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"go/format"
 	"html"
 	"io"
 	"strings"
@@ -139,7 +140,13 @@ type GoExpression struct {
 
 func (exp GoExpression) IsTemplateFileNode() bool { return true }
 func (exp GoExpression) Write(w io.Writer, indent int) error {
-	return writeIndent(w, indent, exp.Expression.Value)
+	data, err := format.Source([]byte(exp.Expression.Value))
+	if err != nil {
+		return writeIndent(w, indent, exp.Expression.Value)
+	}
+
+	_, err = w.Write(data)
+	return err
 }
 
 func writeIndent(w io.Writer, level int, s string) (err error) {

--- a/parser/v2/types_test.go
+++ b/parser/v2/types_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFormatting(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name     string
 		input    string
 		expected string
@@ -518,6 +518,53 @@ package main
 
 templ x() {
 	<div>{ pt1 }{ pt2 }</div>
+}
+`,
+		},
+		{
+			name: "written Go must be formatted with builtin Go formatter",
+			input: ` // first line removed to make indentation clear
+package main
+
+      type Link struct {
+Name string
+	        Url  string
+}
+
+var a = false;
+
+func test() {
+	      log.Print("hoi")
+
+	      if (a) {
+      log.Fatal("OH NO !")
+	}
+}
+
+templ x() {
+	<div>Hello World</div>
+}
+`,
+			expected: ` // first line removed to make indentation clear
+package main
+
+type Link struct {
+	Name string
+	Url  string
+}
+
+var a = false
+
+func test() {
+	log.Print("hoi")
+
+	if a {
+		log.Fatal("OH NO !")
+	}
+}
+
+templ x() {
+	<div>Hello World</div>
 }
 `,
 		},


### PR DESCRIPTION
This PR solves the problem as written in the Issue #208 that `go templ` formats Go code which can be written alongside the `templ` keyword.

I'm still new to the go ecosystem but saw what was done in PR #102 with the `go/format` package. 
I think my little modification to format the code with this package when generating the clean string version is good.

Of course I'm open to any improvement.