### PR TITLE
Changing the maximum size of an element name to 32

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -313,9 +313,9 @@ var (
 			in.Seek(start)
 			return
 		}
-		if len(suffix)+1 > 16 {
+		if len(suffix)+1 > 32 {
 			ok = false
-			err = parse.Error("element property names must be < 16 characters long", in.Position())
+			err = parse.Error("element property names must be < 32 characters long", in.Position())
 			return
 		}
 		return prefix + suffix, true, nil


### PR DESCRIPTION
So this PR is very simple. 

I don't know but for some reason the maximum size allowed for an element is 16. 

We can assume this is fair enough for HTML name but in reality. Something beautiful exist too.

HTML can be extend with custom element and custom element can have long name quickly.

For example in my code I have a custom element name `<app-parallax-bacgrkound>`.
Just this name is 23 characters longs.

So I don't know the reason initial for 16 but I bump up this number to 32 so Templ generator can support every custom element with long name. 

Note: When I change this value I didn't see any unit test broke. I'm not sure If I need so to write one for this guard but I think this don't really matter since I just edit a value that already exist ?