### PR TITLE
fix: hang after m.Lock in KillAll (caused by #181)

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -62,7 +62,7 @@ func Run(args Arguments) (err error) {
 		select {
 		case <-signalChan: // First signal, cancel context.
 			fmt.Println("\nCancelling...")
-			err = run.KillAll()
+			err = run.Stop()
 			if err != nil {
 				fmt.Printf("Error killing command: %v\n", err)
 			}


### PR DESCRIPTION
My recent PR (#181) had an issue where it would hang on the run on KillAll, as it would lock the mutex, then attempt to lock it again. This has been resolved by moving the KillAll to before the mutex is locked as part of Run.

This PR also renames KillAll to Stop for clarity.