### PR TITLE
chore: update readme in preparation for awesome-go application

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@
 
 See user documentation at https://templ.guide
 
+<p align="center">
 [![Go Reference](https://pkg.go.dev/badge/github.com/a-h/templ.svg)](https://pkg.go.dev/github.com/a-h/templ)
 [![xc compatible](https://xcfile.dev/badge.svg)](https://xcfile.dev)
 [![Go Coverage](https://github.com/a-h/templ/wiki/coverage.svg)](https://raw.githack.com/wiki/a-h/templ/coverage.html)
+[![Go Report Card](https://goreportcard.com/badge/github.com/a-h/templ)](https://goreportcard.com/report/github.com/a-h/templ)
+</p>
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 See user documentation at https://templ.guide
 
 <p align="center">
-[![Go Reference](https://pkg.go.dev/badge/github.com/a-h/templ.svg)](https://pkg.go.dev/github.com/a-h/templ)
-[![xc compatible](https://xcfile.dev/badge.svg)](https://xcfile.dev)
-[![Go Coverage](https://github.com/a-h/templ/wiki/coverage.svg)](https://raw.githack.com/wiki/a-h/templ/coverage.html)
-[![Go Report Card](https://goreportcard.com/badge/github.com/a-h/templ)](https://goreportcard.com/report/github.com/a-h/templ)
+<a href="https://pkg.go.dev/github.com/a-h/templ"><img src="https://pkg.go.dev/badge/github.com/a-h/templ.svg" alt="Go Reference" /></a>
+<a href="https://xcfile.dev"><img src="https://xcfile.dev/badge.svg" alt="xc compatible" /></a>
+<a href="https://raw.githack.com/wiki/a-h/templ/coverage.html"><img src="https://github.com/a-h/templ/wiki/coverage.svg" alt="Go Coverage" /></a>
+<a href="https://goreportcard.com/report/github.com/a-h/templ"><img src="https://goreportcard.com/badge/github.com/a-h/templ" alt="Go Report Card" /></a<
 </p>
 
 ## Tasks


### PR DESCRIPTION
Adds the Go Report card and centres all the cards in the README. 

You can see the layout [here](https://github.com/valxntine/templ/tree/update-readme-awesome-go)

Whilst aligning them all in the centre looks "nicer", its made me question if they would be better living under the Templ gif in the README rather than in the documentation section? I'll let someone else decide that and I can make the change if needs be.

Also if you don't care about the cards being in the centre, I can change that back. 

I don't think this specifically closes #196 but gets us a step closer as I can open a PR in awesome-go once this is all merged.