### PR TITLE
docs: add section for format on save in neovim

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -73,6 +73,28 @@ vim.filetype.add({
 })
 ```
 
+### Format on Save
+
+With the templ LSP installed and configured, you can use the following code snippet to format on save:
+
+
+```lua
+-- Format current buffer using LSP.
+vim.api.nvim_create_autocmd(
+  {
+    -- 'BufWritePre' event triggers just before a buffer is written to file.
+    "BufWritePre"
+  },
+  {
+    pattern = {"*.templ"},
+    callback = function()
+      -- Format the current buffer using Neovim's built-in LSP (Language Server Protocol).
+      vim.lsp.buf.format()
+    end,
+  }
+)
+```
+
 ### Tailwind CSS Intellisense
 
 In order to enable autocompletion for Tailwindcss CSS in `.templ` files make sure to add the following config:


### PR DESCRIPTION
Adds section to documentation on how to format `*.templ` files on save in neovim.