### PR TITLE
docs: fix typo/wrong order in neovim tailwindcss section

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -83,8 +83,8 @@ require("lspconfig").tailwindcss.setup({
     'templ'
     -- include any other filetypes where you need tailwindcss
   },
-  userLanguages = {
-    init_options = {
+  init_options = {
+    userLanguages = {
         templ = "html"
     }
   }


### PR DESCRIPTION
fixes wrong order in the tailwindcss config introduced in my last PR