### PR TITLE
match prefix of Content-Type header in proxy

### DIFF
--- a/cmd/templ/generatecmd/proxy/proxy.go
+++ b/cmd/templ/generatecmd/proxy/proxy.go
@@ -32,7 +32,7 @@ func New(port int, target *url.URL) *Handler {
 	p := httputil.NewSingleHostReverseProxy(target)
 	p.ErrorLog = log.New(os.Stderr, "Proxy to target error: ", 0)
 	p.ModifyResponse = func(r *http.Response) error {
-		if contentType := r.Header.Get("Content-Type"); contentType != "text/html" {
+		if contentType := r.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "text/html") {
 			return nil
 		}
 		body, err := io.ReadAll(r.Body)


### PR DESCRIPTION
When deciding whether to modify response and include the SSE listener script, match the Content-Type header based on prefix only so `text/html; charset=utf-8` is also applicable.
based on #146 