### PR TITLE
feat: proxy retries with exponential backoff

### DIFF
--- a/cmd/templ/generatecmd/proxy/proxy.go
+++ b/cmd/templ/generatecmd/proxy/proxy.go
@@ -32,7 +32,7 @@ func New(port int, target *url.URL) *Handler {
 	p := httputil.NewSingleHostReverseProxy(target)
 	p.ErrorLog = log.New(os.Stderr, "Proxy to target error: ", 0)
 	p.ModifyResponse = func(r *http.Response) error {
-		if contentType := r.Header.Get("Content-Type"); contentType != "text/html" {
+		if contentType := r.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "text/html") {
 			return nil
 		}
 		body, err := io.ReadAll(r.Body)


### PR DESCRIPTION
Proxy will retry on error for 10 times, so server has some time to come up after reloading/restarting.

Tested with `templ generate --watch --proxy="http://127.0.0.1:8089" --proxyport="8080" --cmd="go run ."`

Open to ideas whether the backoff should be user configurable.

based on #146 