### PR TITLE
fix: set content type correctly on gin example

### DIFF
--- a/examples/integration-gin/renderer.go
+++ b/examples/integration-gin/renderer.go
@@ -14,6 +14,7 @@ type TemplRender struct {
 }
 
 func (t TemplRender) Render(w http.ResponseWriter) error {
+	t.WriteContentType(w)
 	w.WriteHeader(t.Code)
 	if t.Data != nil {
 		return t.Data.Render(context.Background(), w)


### PR DESCRIPTION
When using the gin example, the response is plain text and does not get rendered as HTML, due to the `WriteContentType` method not being called.