### PR TITLE
Correct class value in 09-template-composition.md

### DIFF
--- a/docs/docs/03-syntax-and-usage/09-template-composition.md
+++ b/docs/docs/03-syntax-and-usage/09-template-composition.md
@@ -107,7 +107,7 @@ func main() {
 <div id="heading">
 	<h1>Heading</h1>
 </div>
-<div id="right">
+<div id="contents">
 	<p>Dynamic contents</p>
 </div>
 ```
@@ -156,7 +156,7 @@ func main() {
 <div id="heading">
 	<h1>Heading</h1>
 </div>
-<div id="right">
+<div id="contents">
 	<p>Dynamic contents</p>
 </div>
 ```


### PR DESCRIPTION
`class="right"` should be `class="contents"` based on the components defined at the beginning of the *Components as parameters* section.