### PR TITLE
Changing the maximum size of an element name to 128

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -313,9 +313,9 @@ var (
 			in.Seek(start)
 			return
 		}
-		if len(suffix)+1 > 64 {
+		if len(suffix)+1 > 128 {
 			ok = false
-			err = parse.Error("element names must be < 64 characters long", in.Position())
+			err = parse.Error("element names must be < 128 characters long", in.Position())
 			return
 		}
 		return prefix + suffix, true, nil

--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -313,9 +313,9 @@ var (
 			in.Seek(start)
 			return
 		}
-		if len(suffix)+1 > 32 {
+		if len(suffix)+1 > 64 {
 			ok = false
-			err = parse.Error("element names must be < 32 characters long", in.Position())
+			err = parse.Error("element names must be < 64 characters long", in.Position())
 			return
 		}
 		return prefix + suffix, true, nil

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -956,13 +956,13 @@ func TestElementParserErrors(t *testing.T) {
 				}),
 		},
 		{
-			name:  "element: names cannot be greater than 32 characters",
-			input: `<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa></aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>`,
-			expected: parse.Error("element names must be < 32 characters long",
+			name:  "element: names cannot be greater than 64 characters",
+			input: `<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa></aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>`,
+			expected: parse.Error("element names must be < 64 characters long",
 				parse.Position{
-					Index: 34,
+					Index: 66,
 					Line:  0,
-					Col:   34,
+					Col:   66,
 				}),
 		},
 	}

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -956,13 +956,13 @@ func TestElementParserErrors(t *testing.T) {
 				}),
 		},
 		{
-			name:  "element: names cannot be greater than 64 characters",
-			input: `<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa></aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>`,
-			expected: parse.Error("element names must be < 64 characters long",
+			name:  "element: names cannot be greater than 128 characters",
+			input: `<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa></aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>`,
+			expected: parse.Error("element names must be < 128 characters long",
 				parse.Position{
-					Index: 66,
+					Index: 130,
 					Line:  0,
-					Col:   66,
+					Col:   130,
 				}),
 		},
 	}


### PR DESCRIPTION
So this PR is exactly the same thing of my PR #212 except I make the maximum size twice as actual.

Why change again ? Is 32 not long enough ? Well yes and no for me...

In my project I need to create some custom element who represent an administration task form controller.
For this the name should be `<admin-create-reservation-controller>` since it's represent what the custom element do. 
***Except this example is 35 longs...***

So this is why I remade the same PR as #212.

But now I was wondering ? Why is Templ limit the maximum length of an element ? Web Component don't have any restriction on their name so why ?