### PR TITLE
fix: 'generate -watch' stops sleeping between iterations after 15min

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -129,6 +129,8 @@ func runCmd(ctx context.Context, w io.Writer, args Arguments) (err error) {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = time.Millisecond * 500
 	bo.MaxInterval = time.Second * 3
+	bo.MaxElapsedTime = 0
+
 	var firstRunComplete bool
 	fileNameToLastModTime := make(map[string]time.Time)
 	for !firstRunComplete || args.Watch {


### PR DESCRIPTION
fix: 'generate -watch' stops sleeping between iterations after 15min

`backoff.NewExponentialBackOff()` uses `DefaultMaxElapsedTime = 15 * time.Minute`

This causes 'templ generate -watch' to stop sleeping between iterations and watch for file updates constantly which in not ideal CPU utilization.

For more details, take a look at [backoff implementation](https://github.com/cenkalti/backoff/blob/v4/exponential.go).