### PR TITLE
Response headers, status code, and error handling

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -69,10 +69,12 @@ const componentHandlerErrorMessage = "templ: failed to render template"
 
 // ServeHTTP implements the http.Handler interface.
 func (ch ComponentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set header before writing status, otherwise
+	// this header won't be written to response.
+	w.Header().Add("Content-Type", ch.ContentType)
 	if ch.Status != 0 {
 		w.WriteHeader(ch.Status)
 	}
-	w.Header().Add("Content-Type", ch.ContentType)
 	err := ch.Component.Render(r.Context(), w)
 	if err != nil {
 		if ch.ErrorHandler != nil {

--- a/runtime.go
+++ b/runtime.go
@@ -69,29 +69,27 @@ const componentHandlerErrorMessage = "templ: failed to render template"
 
 // ServeHTTP implements the http.Handler interface.
 func (ch ComponentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// There may be error, don't write to response yet.
-	// Component impl will use this buffer directly!
+	// Since the component may error, write to a buffer first.
+	// This prevents partial responses from being written to the client.
 	buf := GetBuffer()
 	defer ReleaseBuffer(buf)
 	err := ch.Component.Render(r.Context(), buf)
-	if err == nil {
-		// Set header before writing status, otherwise
-		// this header won't be written to response.
-		w.Header().Set("Content-Type", ch.ContentType)
-		if ch.Status != 0 {
-			w.WriteHeader(ch.Status)
+	if err != nil {
+		if ch.ErrorHandler != nil {
+			w.Header().Set("Content-Type", ch.ContentType)
+			ch.ErrorHandler(r, err).ServeHTTP(w, r)
+			return
 		}
-		// Ignore write error like http.Error() does.
-		// There is no way to recover at this point.
-		_, _ = w.Write(buf.Bytes())
-	} else if ch.ErrorHandler != nil {
-		// Don't write status code, error handler may
-		// want to set its own status code and headers.
-		w.Header().Set("Content-Type", ch.ContentType)
-		ch.ErrorHandler(r, err).ServeHTTP(w, r)
-	} else {
 		http.Error(w, componentHandlerErrorMessage, http.StatusInternalServerError)
+		return
 	}
+	w.Header().Set("Content-Type", ch.ContentType)
+	if ch.Status != 0 {
+		w.WriteHeader(ch.Status)
+	}
+	// Ignore write error like http.Error() does, because there is
+	// no way to recover at this point.
+	_, _ = w.Write(buf.Bytes())
 }
 
 // Handler creates a http.Handler that renders the template.

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -382,6 +382,9 @@ func TestHandler(t *testing.T) {
 		return nil
 	})
 	errorComponent := templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		if _, err := io.WriteString(w, "Hello"); err != nil {
+			t.Fatalf("failed to write string: %v", err)
+		}
 		return errors.New("handler error")
 	})
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -386,28 +386,39 @@ func TestHandler(t *testing.T) {
 	})
 
 	tests := []struct {
-		name           string
-		input          *templ.ComponentHandler
-		expectedStatus int
-		expectedBody   string
+		name             string
+		input            *templ.ComponentHandler
+		expectedStatus   int
+		expectedMIMEType string
+		expectedBody     string
 	}{
 		{
-			name:           "handlers return OK by default",
-			input:          templ.Handler(hello),
-			expectedStatus: http.StatusOK,
-			expectedBody:   "Hello",
+			name:             "handlers return OK by default",
+			input:            templ.Handler(hello),
+			expectedStatus:   http.StatusOK,
+			expectedMIMEType: "text/html",
+			expectedBody:     "Hello",
 		},
 		{
-			name:           "handlers can be configured to return an alternative status code",
-			input:          templ.Handler(hello, templ.WithStatus(http.StatusNotFound)),
-			expectedStatus: http.StatusNotFound,
-			expectedBody:   "Hello",
+			name:             "handlers can be configured to return an alternative status code",
+			input:            templ.Handler(hello, templ.WithStatus(http.StatusNotFound)),
+			expectedStatus:   http.StatusNotFound,
+			expectedMIMEType: "text/html",
+			expectedBody:     "Hello",
 		},
 		{
-			name:           "handlers that fail return a 500 error",
-			input:          templ.Handler(errorComponent),
-			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   "templ: failed to render template\n",
+			name:             "handlers can be configured to return an alternative status code and content type",
+			input:            templ.Handler(hello, templ.WithStatus(http.StatusOK), templ.WithContentType("text/csv")),
+			expectedStatus:   http.StatusOK,
+			expectedMIMEType: "text/csv",
+			expectedBody:     "Hello",
+		},
+		{
+			name:             "handlers that fail return a 500 error",
+			input:            templ.Handler(errorComponent),
+			expectedStatus:   http.StatusInternalServerError,
+			expectedMIMEType: "text/plain; charset=utf-8",
+			expectedBody:     "templ: failed to render template\n",
 		},
 		{
 			name: "error handling can be customised",
@@ -421,8 +432,9 @@ func TestHandler(t *testing.T) {
 					}
 				})
 			})),
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   "custom body",
+			expectedStatus:   http.StatusBadRequest,
+			expectedMIMEType: "text/html",
+			expectedBody:     "custom body",
 		},
 	}
 	for _, tt := range tests {
@@ -433,6 +445,9 @@ func TestHandler(t *testing.T) {
 			tt.input.ServeHTTP(w, r)
 			if got := w.Result().StatusCode; tt.expectedStatus != got {
 				t.Errorf("expected status %d, got %d", tt.expectedStatus, got)
+			}
+			if mimeType := w.Result().Header.Get("Content-Type"); tt.expectedMIMEType != mimeType {
+				t.Errorf("expected content-type %s, got %s", tt.expectedMIMEType, mimeType)
 			}
 			body, err := io.ReadAll(w.Result().Body)
 			if err != nil {


### PR DESCRIPTION
Proposed handler fixes and error handling improvements for #315

The general idea is to render component into a buffer before writing it to response, so that in the event of error, error handler can write its own response with correct status code and headers. The buffer is obtained with `GetBuffer()` and component should be able to use it directly as if it obtained buffer on its own.

Additionally, handler now sets headers to header map before writing response code, and does not write response code when calling error handler so that it can set its own headers and response code.