### PR TITLE
Fix typo in "View models" page

### DIFF
--- a/docs/docs/04-core-concepts/04-view-models.md
+++ b/docs/docs/04-core-concepts/04-view-models.md
@@ -21,7 +21,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
      //TODO: Log error server side.
   }
   m := NewInviteComponentViewModel(invites, err)
-  teamInviteComponentModel(m).Render(r.Context(), w)
+  teamInviteComponent(m).Render(r.Context(), w)
 }
 
 func NewInviteComponentViewModel(invites []models.Invite, err error) (m InviteComponentViewModel) {


### PR DESCRIPTION
Hi,

I think since this is rendering the component it's supposed to be `teamInviteComponent` instead of `teamInviteComponentModel`? May be misunderstanding how it works though.

Thanks!