### PR TITLE
Feature: default to delete orphaned files, with -keepOrphanedFiles argument flag to disable feature

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -145,11 +145,10 @@ func runCmd(ctx context.Context, w io.Writer, args Arguments) (err error) {
 					// the .templ file exists, so we don't delete the generated file
 					return nil
 				}
-				logSuccess(w, "Deleted orphaned file %q in %s\n", fileName, time.Since(start))
 				if err = os.Remove(fileName); err != nil {
 					return fmt.Errorf("failed to remove file: %w", err)
 				}
-
+				logSuccess(w, "Deleted orphaned file %q in %s\n", fileName, time.Since(start))
 			}
 			return nil
 		})

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -224,7 +224,7 @@ func processChanges(ctx context.Context, stdout io.Writer, fileNameToLastModTime
 			// Make sure the generated file is orphaned
 			// by checking if the corresponding .templ file exists.
 			if _, err := os.Stat(strings.TrimSuffix(fileName, "_templ.go") + ".templ"); err == nil {
-				// the .templ file exists, so we don't delete the generated file
+				// The .templ file exists, so we don't delete the generated file.
 				return nil
 			}
 			if err = os.Remove(fileName); err != nil {

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -221,7 +221,7 @@ func processChanges(ctx context.Context, stdout io.Writer, fileNameToLastModTime
 			return nil
 		}
 		if !keepOrphanedFiles && strings.HasSuffix(fileName, "_templ.go") {
-			// lets make sure the generated file is orphaned
+			// Make sure the generated file is orphaned
 			// by checking if the corresponding .templ file exists
 			if _, err := os.Stat(strings.TrimSuffix(fileName, "_templ.go") + ".templ"); err == nil {
 				// the .templ file exists, so we don't delete the generated file

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -145,7 +145,7 @@ func runCmd(ctx context.Context, w io.Writer, args Arguments) (err error) {
 					// the .templ file exists, so we don't delete the generated file
 					return nil
 				}
-				logSuccess(w, "Deleting orphaned compiled file %q in %s\n", fileName, time.Since(start))
+				logSuccess(w, "Deleted orphaned file %q in %s\n", fileName, time.Since(start))
 				if err = os.Remove(fileName); err != nil {
 					return fmt.Errorf("failed to remove file: %w", err)
 				}

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -222,7 +222,7 @@ func processChanges(ctx context.Context, stdout io.Writer, fileNameToLastModTime
 		}
 		if !keepOrphanedFiles && strings.HasSuffix(fileName, "_templ.go") {
 			// Make sure the generated file is orphaned
-			// by checking if the corresponding .templ file exists
+			// by checking if the corresponding .templ file exists.
 			if _, err := os.Stat(strings.TrimSuffix(fileName, "_templ.go") + ".templ"); err == nil {
 				// the .templ file exists, so we don't delete the generated file
 				return nil

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -120,6 +120,7 @@ func generateCmd(w io.Writer, args []string) (code int) {
 	proxyPortFlag := cmd.Int("proxyport", 7331, "")
 	workerCountFlag := cmd.Int("w", runtime.NumCPU(), "")
 	pprofPortFlag := cmd.Int("pprof", 0, "")
+	keepOrphanedFilesFlag := cmd.Bool("keep-orphaned-files", false, "")
 	helpFlag := cmd.Bool("help", false, "")
 	err := cmd.Parse(args)
 	if err != nil || *helpFlag {
@@ -138,6 +139,7 @@ func generateCmd(w io.Writer, args []string) (code int) {
 		IncludeVersion:                  *includeVersionFlag,
 		IncludeTimestamp:                *includeTimestampFlag,
 		PPROFPort:                       *pprofPortFlag,
+		KeepOrphanedFiles:               *keepOrphanedFilesFlag,
 	})
 	if err != nil {
 		color.New(color.FgRed).Fprint(w, "(✗) ")

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -88,6 +88,8 @@ Args:
     Number of workers to use when generating code. (default runtime.NumCPUs)
   -pprof
     Port to run the pprof server on.
+  -keep-orphaned-files
+    Keeps orphaned generated templ files. (default false)
   -help
     Print help and exit.
 


### PR DESCRIPTION
Added default functionality to delete orphans on `templ generate`
![image](https://github.com/a-h/templ/assets/12313444/97cd9a72-2bd9-492e-849a-8158c2d02a35)
& with the -keep-orphaned-files arg flag
![image](https://github.com/a-h/templ/assets/12313444/fc921ee1-5293-42d0-8b01-08c5a329ba6e)
(base2_templ.go isn't deleted)


