### PR TITLE
docs: change `go run` command

### DIFF
--- a/docs/docs/02-quick-start/02-creating-a-simple-templ-component.md
+++ b/docs/docs/02-quick-start/02-creating-a-simple-templ-component.md
@@ -73,7 +73,7 @@ func main() {
 Running the code will render the component's HTML to stdout.
 
 ```sh
-go run *.go
+go run .
 ```
 
 ```html title="Output"


### PR DESCRIPTION
`go run *.go` doesn't work on Windows, whereas `go run .` is cross-platform and has the same effect in this case.

Fixes #331