### PR TITLE
[docs] Enable templ syntax highlighting in 04-core-concepts/01-components

### DIFF
--- a/docs/docs/04-core-concepts/01-components.md
+++ b/docs/docs/04-core-concepts/01-components.md
@@ -63,7 +63,7 @@ templ components can be returned from methods (functions attached to types).
 
 Go code:
 
-```
+```templ
 package main
 
 type Data struct {


### PR DESCRIPTION
I noticed that the last code block in [this docs page](https://templ.guide/core-concepts/components/) doesn't have syntax highlighting.