### PR TITLE
docs: added neovim lsp, formatting, and troubleshooting information. …

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -64,6 +64,7 @@ end
 ```
 
 In Neovim, you can use the `:LspInfo` command to check which Language Servers (if any) are running. If the expected language server has not started, it could be due to the unregistered templ file extension. 
+
 To resolve this issue, add the following code to your configuration. This is also necessary for other LSPs to "pick up" on .templ files.
 
 ```lua

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -86,6 +86,7 @@ lspconfig.html.setup({
 ```
 
 [htmx-lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#htmx) - First make sure you have it installed `:LspInstall htmx` or find it on the `:Mason` list. Note with this LSP, it activates after you type `hx-` in an html attribute, because that's how all htmx attributes are written.
+
 ```lua
 lspconfig.htmx.setup({
     on_attach = on_attach,

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -37,80 +37,156 @@ Include the following to the settings.json in order to enable autocompletion for
 
 ## Neovim &gt; 0.5.0
 
-A vim / neovim plugin is available from https://github.com/Joe-Davidson1802/templ.vim which adds syntax highlighting.
+A plugin written in VimScript which adds syntax highlighting: [joerdav/templ.vim](https://github.com/Joe-Davidson1802/templ.vim).
 
-For neovim you can also use [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for syntax highlighting with the custom parser [tree-sitter-templ](https://github.com/vrischmann/tree-sitter-templ).
+For neovim you can use [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) and install [tree-sitter-templ](https://github.com/vrischmann/tree-sitter-templ) with `:TSInstall templ`.
 
 The configuration for the templ Language Server is included in [lspconfig](https://github.com/neovim/nvim-lspconfig), [mason](https://github.com/williamboman/mason.nvim),
 and [mason-lspconfig](https://github.com/williamboman/mason-lspconfig.nvim).
 
+The `templ` command must be in your system path for the LSP to be able to start. Ensure that you can run it from the command line before continuing.
+
 Installing and configuring the templ LSP is no different to setting up any other Language Server.
 
 ```lua
+local lspconfig = require("lspconfig")
+
 -- Use a loop to conveniently call 'setup' on multiple servers and
 -- map buffer local keybindings when the language server attaches
+
 local servers = { 'gopls', 'ccls', 'cmake', 'tsserver', 'templ' }
 for _, lsp in ipairs(servers) do
-  nvim_lsp[lsp].setup {
+  lspconfig[lsp].setup({
     on_attach = on_attach,
-    flags = {
-      debounce_text_changes = 150,
-    },
-  }
+    capabilities = capabilities,
+  })
 end
 ```
 
-The `templ` command must be in your system path for the LSP to be able to start.
-
-In Neovim, you can use the `:LspInfo` command to check which Language Servers (if any) are running. If the expected language server has not started, it could be due to the unregistered templ file extension. To resolve this issue, add the following code to your configuration:
+In Neovim, you can use the `:LspInfo` command to check which Language Servers (if any) are running. If the expected language server has not started, it could be due to the unregistered templ file extension. 
+To resolve this issue, add the following code to your configuration. This is also necessary for other LSPs to "pick up" on .templ files.
 
 ```lua
--- additional filetypes
-vim.filetype.add({
- extension = {
-  templ = "templ",
- },
+vim.filetype.add({ extension = { templ = "templ" } })
+```
+
+##### Other LSPs within .templ files
+
+These LSPs can be used *in conjunction* with the templ lsp and tree-sitter. Here's how to set them up.
+
+[html-lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#html) - First make sure you have it installed `:LspInstall html` or find it on the `:Mason` list. 
+```lua
+lspconfig.html.setup({
+    on_attach = on_attach,
+    capabilities = capabilities,
+    filetypes = { "html", "templ" },
 })
 ```
 
-### Format on Save
+[htmx-lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#htmx) - First make sure you have it installed `:LspInstall htmx` or find it on the `:Mason` list. Note with this LSP, it activates after you type `hx-` in an html attribute, because that's how all htmx attributes are written.
+```lua
+lspconfig.htmx.setup({
+    on_attach = on_attach,
+    capabilities = capabilities,
+    filetypes = { "html", "templ" },
+})
+```
+
+[tailwindcss](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tailwindcss) - First make sure you have it installed `:LspInstall tailwindcss` or find it on the `:Mason` list.
+```lua
+lspconfig.tailwindcss.setup({
+    on_attach = on_attach,
+    capabilities = capabilities,
+    filetypes = { "templ", "astro", "javascript", "typescript", "react" },
+    init_options = { userLanguages = { templ = "html" } },
+})
+```
+
+Inside of your `tailwind.config.js`, you need to tell tailwind to look inside of .templ files and/or .go files.
+```js
+module.exports = {
+    content: [ "./**/*.html", "./**/*.templ", "./**/*.go", ],
+    theme: { extend: {}, },
+    plugins: [],
+}
+```
+
+### Formatting
 
 With the templ LSP installed and configured, you can use the following code snippet to format on save:
 
 
 ```lua
--- Format current buffer using LSP.
-vim.api.nvim_create_autocmd(
-  {
-    -- 'BufWritePre' event triggers just before a buffer is written to file.
-    "BufWritePre"
-  },
-  {
-    pattern = {"*.templ"},
-    callback = function()
-      -- Format the current buffer using Neovim's built-in LSP (Language Server Protocol).
-      vim.lsp.buf.format()
-    end,
-  }
-)
+vim.api.nvim_create_autocmd({ "BufWritePre" }, { pattern = { "*.templ" }, callback = vim.lsp.buf.format })
 ```
+`BufWritePre` means that the callback gets ran after you call `:write`.
 
-### Tailwind CSS Intellisense
-
-In order to enable autocompletion for Tailwindcss CSS in `.templ` files make sure to add the following config:
+If you have multiple LSPs attached to the same buffer, and you have issues with `vim.lsp.buf.format`, you can use this snippet to run `templ fmt` in the same way that you might from the command line.
+This will get the buffer and its corresponding filename, and refresh the buffer after it has been formatted so you don't get out of sync issues.
 
 ```lua
-require("lspconfig").tailwindcss.setup({
-  filetypes = {
-    'templ'
-    -- include any other filetypes where you need tailwindcss
-  },
-  init_options = {
-    userLanguages = {
-        templ = "html"
-    }
-  }
-})
+local custom_format = function()
+    if vim.bo.filetype == "templ" then
+        local bufnr = vim.api.nvim_get_current_buf()
+        local filename = vim.api.nvim_buf_get_name(bufnr)
+        local cmd = "templ fmt " .. vim.fn.shellescape(filename)
+
+        vim.fn.jobstart(cmd, {
+            on_exit = function()
+                -- Reload the buffer only if it's still the current buffer
+                if vim.api.nvim_get_current_buf() == bufnr then
+                    vim.cmd('e!')
+                end
+            end,
+        })
+    else
+        vim.lsp.buf.format()
+    end
+end
+```
+
+To apply this `custom_format` in your neovim configuration as a keybinding, apply it to the `on_attach` function.
+
+```lua
+local on_attach = function(client, bufnr)
+    local opts = { buffer = bufnr, remap = false }
+    -- other configuration options
+    vim.keymap.set("n", "<leader>lf", custom_format, opts)
+end
+```
+
+To make this `custom_format` run on save, make the same autocmd from before and replace the callback with `custom_format`. 
+```lua
+vim.api.nvim_create_autocmd({ "BufWritePre" }, { pattern = { "*.templ" }, callback = custom_format })
+```
+You can also rewrite the function like so, given that the function will only be executed on .templ files.
+
+```lua
+local templ_format = function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local filename = vim.api.nvim_buf_get_name(bufnr)
+    local cmd = "templ fmt " .. vim.fn.shellescape(filename)
+
+    vim.fn.jobstart(cmd, {
+        on_exit = function()
+            -- Reload the buffer only if it's still the current buffer
+            if vim.api.nvim_get_current_buf() == bufnr then
+                vim.cmd('e!')
+            end
+        end,
+    })
+end
+```
+
+
+
+### Troubleshooting
+
+If you cannot run `:TSInstall templ`, ensure you have an up-to-date version of [tree-sitter](https://github.com/nvim-treesitter/nvim-treesitter). The [package for templ](https://github.com/vrischmann/tree-sitter-templ) was [added to the main tree-sitter repositry](https://github.com/nvim-treesitter/nvim-treesitter/pull/5667) so you shouldn't need to install a separate plugin for it.
+If you still don't get syntax highlighting after it's installed, try running `:TSBufEnable highlight`. If you find that you need to do this every time you open a .templ file, you can run this autocmd to do it for your neovim configuation.
+
+```lua
+vim.api.nvim_create_autocmd("BufEnter", { pattern = "*.templ", callback = function() vim.cmd("TSBufEnable highlight") end }) 
 ```
 
 ## Helix

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -186,8 +186,6 @@ local templ_format = function()
 end
 ```
 
-
-
 ### Troubleshooting
 
 If you cannot run `:TSInstall templ`, ensure you have an up-to-date version of [tree-sitter](https://github.com/nvim-treesitter/nvim-treesitter). The [package for templ](https://github.com/vrischmann/tree-sitter-templ) was [added to the main tree-sitter repositry](https://github.com/nvim-treesitter/nvim-treesitter/pull/5667) so you shouldn't need to install a separate plugin for it.

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -76,6 +76,7 @@ vim.filetype.add({ extension = { templ = "templ" } })
 These LSPs can be used *in conjunction* with the templ lsp and tree-sitter. Here's how to set them up.
 
 [html-lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#html) - First make sure you have it installed `:LspInstall html` or find it on the `:Mason` list. 
+
 ```lua
 lspconfig.html.setup({
     on_attach = on_attach,

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -189,6 +189,7 @@ end
 ### Troubleshooting
 
 If you cannot run `:TSInstall templ`, ensure you have an up-to-date version of [tree-sitter](https://github.com/nvim-treesitter/nvim-treesitter). The [package for templ](https://github.com/vrischmann/tree-sitter-templ) was [added to the main tree-sitter repositry](https://github.com/nvim-treesitter/nvim-treesitter/pull/5667) so you shouldn't need to install a separate plugin for it.
+
 If you still don't get syntax highlighting after it's installed, try running `:TSBufEnable highlight`. If you find that you need to do this every time you open a .templ file, you can run this autocmd to do it for your neovim configuation.
 
 ```lua

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -107,6 +107,7 @@ lspconfig.tailwindcss.setup({
 ```
 
 Inside of your `tailwind.config.js`, you need to tell tailwind to look inside of .templ files and/or .go files.
+
 ```js
 module.exports = {
     content: [ "./**/*.html", "./**/*.templ", "./**/*.go", ],

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -162,6 +162,7 @@ end
 ```
 
 To make this `custom_format` run on save, make the same autocmd from before and replace the callback with `custom_format`. 
+
 ```lua
 vim.api.nvim_create_autocmd({ "BufWritePre" }, { pattern = { "*.templ" }, callback = custom_format })
 ```

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -95,6 +95,7 @@ lspconfig.htmx.setup({
 ```
 
 [tailwindcss](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tailwindcss) - First make sure you have it installed `:LspInstall tailwindcss` or find it on the `:Mason` list.
+
 ```lua
 lspconfig.tailwindcss.setup({
     on_attach = on_attach,

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -127,6 +127,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre" }, { pattern = { "*.templ" }, callba
 `BufWritePre` means that the callback gets ran after you call `:write`.
 
 If you have multiple LSPs attached to the same buffer, and you have issues with `vim.lsp.buf.format`, you can use this snippet to run `templ fmt` in the same way that you might from the command line.
+
 This will get the buffer and its corresponding filename, and refresh the buffer after it has been formatted so you don't get out of sync issues.
 
 ```lua

--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -166,6 +166,7 @@ To make this `custom_format` run on save, make the same autocmd from before and 
 ```lua
 vim.api.nvim_create_autocmd({ "BufWritePre" }, { pattern = { "*.templ" }, callback = custom_format })
 ```
+
 You can also rewrite the function like so, given that the function will only be executed on .templ files.
 
 ```lua

--- a/docs/docs/09-commands-and-tools/03-hot-reload.md
+++ b/docs/docs/09-commands-and-tools/03-hot-reload.md
@@ -16,7 +16,7 @@ templ generate --watch --proxy="http://localhost:8080" --cmd="runtest"
 
 ## Alternative
 
-Air's reload performance is better due to its complex filesystem notification setup, but doens't ship with a proxy to automatically reload pages, and requires a `toml` configuration file for operation.
+Air's reload performance is better due to its complex filesystem notification setup, but doesn't ship with a proxy to automatically reload pages, and requires a `toml` configuration file for operation.
 
 See https://github.com/cosmtrek/air for details.
 


### PR DESCRIPTION
…(#363)

Hopefully this fleshes out the neovim configuration enough for beginners. The formatting section is a bit long, but I wanted to give some more context to said beginners.

All of this was from personal trial and error, so I can rewrite it if anything is inaccurate. Particularly the part about `vim.lsp.buf.format()` not working. I've never gotten it to work on templ, and I expect that's because the LSP is picking up the wrong LSP to format, so that's why I give instructions on how to use the `templ fmt` command from neovim.