### PR TITLE
docs(installation): add nixpkgs installation instruction

### DIFF
--- a/docs/docs/02-quick-start/01-installation.md
+++ b/docs/docs/02-quick-start/01-installation.md
@@ -14,6 +14,12 @@ Download the latest release from https://github.com/a-h/templ/releases/latest
 
 ## Nix
 
+templ is available to install using the nixpkgs-unstable channel.
+
+```sh
+nix-env -f channel:nixpkgs-unstable -iA templ
+```
+
 templ provides a Nix flake with an exported package containing the binary at https://github.com/a-h/templ/blob/main/flake.nix
 
 ```sh


### PR DESCRIPTION
Nix now has support for a more straightforward templ installation on the [unstable channel](https://search.nixos.org/packages?channel=unstable&show=templ&from=0&size=50&sort=relevance&type=packages&query=templ).

I've opted for the `nix-env` command, as Nix users are likely comfortable adapting it to suit their systems.

If required, I could also update this PR to present `nix-shell` and NixOS configuration installation methods. But, would like to know if the previous Nix installation methods are to be kept first.