### PR TITLE
docs: mention that emacs is available on MELPA

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -206,7 +206,9 @@ It will be included in official releases after version 23.05.
 
 ## Emacs
 
-[templ-ts-mode](https://github.com/danderson/templ-ts-mode) is a major mode for templ files that provides syntax highlighting, indentation, and the other usual major mode things. It requires the [tree-sitter parser](https://github.com/vrischmann/tree-sitter-templ). If the parser is missing, the mode asks you on first use whether you want to download and build it via `treesit-install-language-grammar` (requires git and a C compiler).
+[templ-ts-mode](https://github.com/danderson/templ-ts-mode) is a major mode for templ files that provides syntax highlighting, indentation, and the other usual major mode things. It is available on [MELPA](https://melpa.org/#/templ-ts-mode) and can be installed like any other Emacs package.
+
+Templ support requires the [tree-sitter parser for Templ](https://github.com/vrischmann/tree-sitter-templ). If the parser is missing, the mode asks you on first use whether you want to download and build it via `treesit-install-language-grammar` (requires git and a C compiler).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Since my initial PR to document emacs support, the package was published on [MELPA](https://melpa.org/). Mentioning this inline in the Templ documentation would save readers an indirection through github if all they're looking for is "yes there is support, install it the usual way".