### PR TITLE
fix: report templ server info to LSP clients, not gopls info

### DIFF
--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/a-h/parse"
 	lsp "github.com/a-h/protocol"
+	"github.com/a-h/templ"
 	"github.com/a-h/templ/generator"
 	"github.com/a-h/templ/parser/v2"
 	"go.lsp.dev/uri"
@@ -222,6 +223,10 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 		WillSaveWaitUntil: false,
 		Save:              &lsp.SaveOptions{IncludeText: true},
 	}
+
+	result.ServerInfo.Name = "templ-lsp"
+	result.ServerInfo.Version = templ.Version()
+
 	return result, err
 }
 


### PR DESCRIPTION
Fixes #403

---

Fix is so trivial, I figured I'd just send it along so it's ready to go if needed.

If you'd like a little whimsy in the program-to-program comms, I was tempted to have the LSP call itself `templs`. If that appeals, happy to make that change :joy: 