### PR TITLE
docs: Fixes typo on 02-blog-example.md

### DIFF
--- a/docs/docs/06-static-rendering/02-blog-example.md
+++ b/docs/docs/06-static-rendering/02-blog-example.md
@@ -20,7 +20,7 @@ templ contentComponent(title string, body templ.Component) {
 	<body>
 		<h1>{ title }</h1>
 		<div class="content">
-			{! body }
+			@body
 		</div>
 	</body>
 }


### PR DESCRIPTION
Fixes typo, using ! instead of @ to render body component