### PR TITLE
templ fmt: Add a way to emit to stdout even when reading from the filesystem

### DIFF
--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -212,9 +212,15 @@ Format stdin to stdout:
 
   templ fmt < header.templ
 
+Format file or directory to stdout:
+
+  templ fmt -stdout FILE
+
 Args:
   -help
     Print help and exit.
+  -stdout
+    Prints to stdout instead of in-place format
 `
 
 func fmtCmd(w io.Writer, args []string) (code int) {
@@ -224,12 +230,14 @@ func fmtCmd(w io.Writer, args []string) (code int) {
 		fmt.Fprint(w, fmtUsageText)
 	}
 	helpFlag := cmd.Bool("help", false, "")
+	stdout := cmd.Bool("stdout", false, "")
+
 	err := cmd.Parse(args)
 	if err != nil || *helpFlag {
 		cmd.Usage()
 		return
 	}
-	err = fmtcmd.Run(w, args)
+	err = fmtcmd.Run(w, fmtcmd.Arguments{*stdout, cmd.Args()})
 	if err != nil {
 		fmt.Fprintln(w, err.Error())
 		return 1


### PR DESCRIPTION
This seems to be the default behavior on other formatters (gofmt for example).

I'm interested in this change mostly because I use acme and acmego auto-formatter expects this behaviour. I expect the change to be useful in general though since the change reflects other formatters behaviour. 

I also added a warning to arg parsing, it seems only the first argument is used so now it issues a warning about the remaining arguments being discarded.

 