### PR TITLE
Fix concurrent write panic on watch

### DIFF
--- a/cmd/templ/generatecmd/testwatch/watch_test.go
+++ b/cmd/templ/generatecmd/testwatch/watch_test.go
@@ -25,6 +25,7 @@ import (
 var testdata embed.FS
 
 func createTestProject(moduleRoot string) (dir string, err error) {
+	fmt.Printf("creating test project\n")
 	dir, err = os.MkdirTemp("", "templ_watch_test_*")
 	if err != nil {
 		return dir, fmt.Errorf("failed to make test dir: %w", err)
@@ -45,7 +46,7 @@ func createTestProject(moduleRoot string) (dir string, err error) {
 			data = bytes.ReplaceAll(data, []byte("{moduleRoot}"), []byte(moduleRoot))
 			target = filepath.Join(dir, "go.mod")
 		}
-		err = os.WriteFile(target, data, 0660)
+		err = os.WriteFile(target, data, 0o660)
 		if err != nil {
 			return dir, fmt.Errorf("failed to copy file: %w", err)
 		}
@@ -59,7 +60,7 @@ func replaceInFile(name, src, tgt string) error {
 		return err
 	}
 	updated := strings.Replace(string(data), src, tgt, -1)
-	return os.WriteFile(name, []byte(updated), 0660)
+	return os.WriteFile(name, []byte(updated), 0o660)
 }
 
 func getPort() (port int, err error) {


### PR DESCRIPTION
This fixes a panic where the watch command would fail due to a concurrent write on the hashes variable. There are also a few reformatting fixes my linter automatically put in.

```
fatal error: concurrent map writes

goroutine 9 [running]:
github.com/a-h/templ/cmd/templ/generatecmd.generate({0x9d6f00, 0xc000024460}, {0xc00002a380, 0x3e}, {0xc000038930, 0x63}, 0xc00017b890, 0x0, {0xc00003f070, 0x2, ...})
        /home/grindlemire/go/pkg/mod/github.com/a-h/templ@v0.2.543/cmd/templ/generatecmd/main.go:414 +0x665
github.com/a-h/templ/cmd/templ/generatecmd.processSingleFile({0x9d6f00, 0xc000024460}, {0x9d1200, 0xc000066030}, {0xc00002a380, 0x3e}, {0xc000038930, 0x63}, 0x0?, 0x0, ...)
        /home/grindlemire/go/pkg/mod/github.com/a-h/templ@v0.2.543/cmd/templ/generatecmd/main.go:349 +0x106
github.com/a-h/templ/cmd/templ/generatecmd.processChanges.func1.1()
        /home/grindlemire/go/pkg/mod/github.com/a-h/templ@v0.2.543/cmd/templ/generatecmd/main.go:311 +0xf4
created by github.com/a-h/templ/cmd/templ/generatecmd.processChanges.func1 in goroutine 1
        /home/grindlemire/go/pkg/mod/github.com/a-h/templ@v0.2.543/cmd/templ/generatecmd/main.go:309 +0x77e
```