### PR TITLE
docs: Add missing hr render

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -91,6 +91,7 @@ templ usage() {
 
 ```html title="Output"
 <p data-testid="paragraph">Text</p>
+<hr>
 ```
 
 ## URL attributes


### PR DESCRIPTION
the templ example has a hr, that is not shown as rendered in the output. 