### PR TITLE
docs: Add JSON attribute example

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -160,3 +160,20 @@ templ Button(text string) {
 ## CSS attributes
 
 CSS handling is discussed in detail in [CSS style management](css-style-management).
+
+## JSON attributes
+
+If you want to pass any JSON object as an attribute value, you need to serialize it into a string.
+
+```go
+func countriesJSON() string {
+	countries := []string{"Czech Republic", "Slovakia", "United Kingdom", "Germany", "Austria", "Slovenia"}
+	bytes, _ := json.Marshal(countries)
+	return string(bytes)
+}
+```
+```templ
+templ SearchBox() {
+	<search-webcomponent suggestions={ countriesJSON() } />
+}
+```

--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -163,7 +163,7 @@ CSS handling is discussed in detail in [CSS style management](css-style-manageme
 
 ## JSON attributes
 
-If you want to pass any JSON object as an attribute value, you need to serialize it into a string.
+To set an attribute's value to a JSON string (e.g. for HTMX's [hx-vals](https://htmx.org/attributes/hx-vals) or Alpine's [x-data](https://alpinejs.dev/directives/data)), serialize the value to a string using a function.
 
 ```go
 func countriesJSON() string {

--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -171,7 +171,6 @@ func countriesJSON() string {
 	bytes, _ := json.Marshal(countries)
 	return string(bytes)
 }
-```
 ```templ
 templ SearchBox() {
 	<search-webcomponent suggestions={ countriesJSON() } />


### PR DESCRIPTION
Hi, based on our discussion in #454, I added an example into docs on how to pass JSON object as HTML attribute value. I see that meanwhile same question already cropped up in #519. I stick to the more generic usecase so that it nudges the reader in the right way.