### PR TITLE
docs: fix gin html status code overwrite and provide fallback renderer

### DIFF
--- a/examples/integration-gin/home.html
+++ b/examples/integration-gin/home.html
@@ -1,0 +1,1 @@
+<div>Hello world</div>

--- a/examples/integration-gin/main.go
+++ b/examples/integration-gin/main.go
@@ -9,7 +9,12 @@ import (
 
 func main() {
 	engine := gin.Default()
-	engine.HTMLRender = gintemplrenderer.Default
+	engine.LoadHTMLFiles("./home.html")
+
+	//engine.HTMLRender = gintemplrenderer.Default
+
+	ginHtmlRenderer := engine.HTMLRender
+	engine.HTMLRender = &gintemplrenderer.HTMLTemplRenderer{FallbackHtmlRenderer: ginHtmlRenderer}
 
 	// Disable trusted proxy warning.
 	engine.SetTrustedProxies(nil)
@@ -21,6 +26,10 @@ func main() {
 	engine.GET("/with-ctx", func(c *gin.Context) {
 		r := gintemplrenderer.New(c.Request.Context(), http.StatusOK, Home())
 		c.Render(http.StatusOK, r)
+	})
+
+	engine.GET("/with-fallback-renderer", func(c *gin.Context) {
+		c.HTML(http.StatusOK, "home.html", gin.H{})
 	})
 
 	engine.Run(":8080")


### PR DESCRIPTION
Refactoring to better integrate with gin.HTML function (allow different http status code) and optionally add fallback html renderer to gin HTMLRender if no temp component is provided