### PR TITLE
chore(docs): add inline component example

### DIFF
--- a/docs/docs/04-core-concepts/01-components.md
+++ b/docs/docs/04-core-concepts/01-components.md
@@ -84,7 +84,7 @@ func main() {
 }
 ```
 
-It is also possible to initlize a struct and call it's component method inline.
+It is also possible to initialize a struct and call it's component method inline.
 
 ```templ
 package main
@@ -100,9 +100,15 @@ templ (d Data) Method() {
 }
 
 templ Message() {
-	@Data{
-		message: "You can implement methods on a type.",
-	}.Method()
+    <div>
+        @Data{
+            message: "You can implement methods on a type.",
+        }.Method()
+    </div>
+}
+
+func main() {
+	Message().Render(context.Background(), os.Stdout)
 }
 ```
 

--- a/docs/docs/04-core-concepts/01-components.md
+++ b/docs/docs/04-core-concepts/01-components.md
@@ -66,6 +66,8 @@ Go code:
 ```templ
 package main
 
+import "os"
+
 type Data struct {
 	message string
 }
@@ -82,6 +84,25 @@ func main() {
 }
 ```
 
+It is also possible to initlize a struct and call it's component method inline.
 
+```templ
+package main
 
+import "os"
+
+type Data struct {
+	message string
+}
+
+templ (d Data) Method() {
+	<div>{ d.message }</div>
+}
+
+templ Message() {
+	@Data{
+		message: "You can implement methods on a type.",
+	}.Method()
+}
+```
 


### PR DESCRIPTION
Based on #561 

This PR adds missing "os" import to the existing method component example and add a new example for inline struct initialization and component method calling.