### PR TITLE
fix: guard from index out of bounds error in function parsing

### DIFF
--- a/parser/v2/goexpression/fuzz.sh
+++ b/parser/v2/goexpression/fuzz.sh
@@ -12,3 +12,5 @@ echo Expression
 go test -fuzz=FuzzExpression -fuzztime=120s
 echo SliceArgs
 go test -fuzz=FuzzSliceArgs -fuzztime=120s
+echo Funcs
+go test -fuzz=FuzzFuncs -fuzztime=120s

--- a/parser/v2/goexpression/parse.go
+++ b/parser/v2/goexpression/parse.go
@@ -180,6 +180,10 @@ func Func(content string) (name, expr string, err error) {
 		}
 		start := int(fn.Pos()) + len("func")
 		end := fn.Type.Params.End() - 1
+		if len(src) < int(end) {
+			err = errors.New("parser error: function identifier")
+			return false
+		}
 		expr = src[start:end]
 		name = fn.Name.Name
 		return false

--- a/parser/v2/goexpression/testdata/fuzz/FuzzFuncs/46c9ed6c9d427bd2
+++ b/parser/v2/goexpression/testdata/fuzz/FuzzFuncs/46c9ed6c9d427bd2
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("func")


### PR DESCRIPTION
Sometimes a panic could surface with the following incomplete code:

```
package main

templ 
```