### PR TITLE
Update minimum go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/a-h/templ
 
-go 1.20
+go 1.21
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1


### PR DESCRIPTION
Due to the inclusion of log/slog in https://github.com/a-h/templ/pull/470, this is the new minimum version.