### PR TITLE
Check for non-nil error in FindTemplates

### DIFF
--- a/cmd/templ/processor/processor.go
+++ b/cmd/templ/processor/processor.go
@@ -43,6 +43,9 @@ func shouldSkipDir(dir string) bool {
 
 func FindTemplates(srcPath string, output chan<- string) (err error) {
 	return filepath.Walk(srcPath, func(currentPath string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() && shouldSkipDir(currentPath) {
 			return filepath.SkipDir
 		}

--- a/cmd/templ/processor/processor_test.go
+++ b/cmd/templ/processor/processor_test.go
@@ -1,0 +1,19 @@
+package processor
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFindTemplates(t *testing.T) {
+	t.Run("returns an error if the directory does not exist", func(t *testing.T) {
+		output := make(chan string)
+		err := FindTemplates("nonexistent", output)
+		if err == nil {
+			t.Fatal("expected error, but got nil")
+		}
+		if !os.IsNotExist(err) {
+			t.Fatalf("expected os.IsNotExist(err) to be true, but got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Resolves #599 

The `fmt` command now correctly handles the error without panicing

```
$ templ fmt "this path does not exist"
(✗)  [ error=lstat this path does not exist: no such file or directory ]
(✓) Format complete [ count=1 errors=1 duration=207.096µs ]
```