### PR TITLE
Fixing docs typo

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -233,6 +233,7 @@ func countriesJSON() string {
 	bytes, _ := json.Marshal(countries)
 	return string(bytes)
 }
+```
 ```templ
 templ SearchBox() {
 	<search-webcomponent suggestions={ countriesJSON() } />


### PR DESCRIPTION
There's a typo in https://templ.guide/syntax-and-usage/attributes .

This is a quick fix.