### PR TITLE
remove redudent comment

### DIFF
--- a/cmd/templ/generatecmd/proxy/proxy_test.go
+++ b/cmd/templ/generatecmd/proxy/proxy_test.go
@@ -272,7 +272,6 @@ func TestProxy(t *testing.T) {
 				}
 			}
 			err = scanner.Err()
-			// We expect the connection to be closed by the server: this is the only way to terminate the sse connection.
 			if err != nil {
 				errChan <- err
 				return


### PR DESCRIPTION
@a-h Thanks for merging #661. I realised I left a redundant comment here.

I used testServer to terminate all connection after I notify proxy, but realised it doesn't work reliably. So now the test sse request listening goroutine will wait for expected result, or timeout to close the connection from the client side. Then the channels will receive and asset and close the test server in defer.
