### PR TITLE
Fix link for "CSS style management"

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -221,7 +221,7 @@ templ Button(text string) {
 
 ## CSS attributes
 
-CSS handling is discussed in detail in [CSS style management](css-style-management).
+CSS handling is discussed in detail in [CSS style management](/syntax-and-usage/css-style-management).
 
 ## JSON attributes
 


### PR DESCRIPTION
Found a 404 on https://templ.guide/syntax-and-usage/attributes/ so here's the fix 🙌