### PR TITLE
Fix overly greedy parsing in raw elements parser

### DIFF
--- a/parser/v2/raw.go
+++ b/parser/v2/raw.go
@@ -28,8 +28,14 @@ func (p rawElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 
 	// Element name.
 	var e RawElement
-	if e.Name, ok, err = parse.String(p.name).Parse(pi); err != nil || !ok {
+	if e.Name, ok, err = elementNameParser.Parse(pi); err != nil || !ok {
 		pi.Seek(start)
+		return
+	}
+
+	if e.Name != p.name {
+		pi.Seek(start)
+		ok = false
 		return
 	}
 

--- a/parser/v2/raw_test.go
+++ b/parser/v2/raw_test.go
@@ -90,3 +90,36 @@ func TestRawElementParser(t *testing.T) {
 		})
 	}
 }
+
+func TestRawElementParserIsNotGreedy(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    string
+		expected RawElement
+	}{
+		{
+			name:  "styles tag",
+			input: `<styles></styles>`,
+		},
+		{
+			name:  "scripts tag",
+			input: `<scripts></scripts>`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			input := parse.NewInput(tt.input)
+			actual, ok, err := rawElements.Parse(input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok {
+				t.Fatalf("unexpected success for input %q", tt.input)
+			}
+			if actual != nil {
+				t.Fatalf("expected nil Node got %v", actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello!

I have been using templ for a project where I am using non-standard HTML elements and I hit a parse error when I used a tag named `<scripts>`.

In the existing code, if the raw element name is successfully parsed, it immediately attempts to parse the attributes, without checking for whitespace or a closing `>`.

This means that something like `<scripts>` would be parsed as a `<script>` tag with a boolean attribute of `s` (the last character of the tag name). This would then give a confusing error about mismatched tags as the closing `</scripts>` tag was actually parsed correctly.

```
--- FAIL: TestRawElementParserIsNotGreedy (0.00s)
    --- FAIL: TestRawElementParserIsNotGreedy/styles_tag (0.00s)
        raw_test.go:115: unexpected error: <style>: expected end tag not present: line 0, col 8
    --- FAIL: TestRawElementParserIsNotGreedy/scripts_tag (0.00s)
        raw_test.go:115: unexpected error: <script>: expected end tag not present: line 0, col 9
```

This commit fixes this issue by delegating to the `elementNameParser`, which checks for white space or a closing `>`, and then compares the name of the expected raw element.