### PR TITLE
fix: set headers before calling WriteHeader

### DIFF
--- a/examples/integration-echo/main.go
+++ b/examples/integration-echo/main.go
@@ -15,8 +15,8 @@ func main() {
 
 // This custom Render replaces Echo's echo.Context.Render() with templ's templ.Component.Render().
 func Render(ctx echo.Context, statusCode int, t templ.Component) error {
-	ctx.Response().Writer.WriteHeader(statusCode)
 	ctx.Response().Header().Set(echo.HeaderContentType, echo.MIMETextHTML)
+	ctx.Response().Writer.WriteHeader(statusCode)
 	return t.Render(ctx.Request().Context(), ctx.Response().Writer)
 }
 


### PR DESCRIPTION
While WriteHeader correctly infers the Content-Type as HTML in the example, the correct way to use ResponseWriter is to set the response headers first, then call WriteHeader.