### PR TITLE
chore: update echo example

### DIFF
--- a/examples/integration-echo/main.go
+++ b/examples/integration-echo/main.go
@@ -15,9 +15,14 @@ func main() {
 
 // This custom Render replaces Echo's echo.Context.Render() with templ's templ.Component.Render().
 func Render(ctx echo.Context, statusCode int, t templ.Component) error {
-	ctx.Response().Header().Set(echo.HeaderContentType, echo.MIMETextHTML)
-	ctx.Response().Writer.WriteHeader(statusCode)
-	return t.Render(ctx.Request().Context(), ctx.Response().Writer)
+	buf := templ.GetBuffer()
+	defer templ.ReleaseBuffer(buf)
+
+	if err := t.Render(ctx.Request().Context(), buf); err != nil {
+		return err
+	}
+
+	return ctx.HTML(statusCode, buf.String())
 }
 
 func HomeHandler(c echo.Context) error {


### PR DESCRIPTION
The previous implementation did not play nice with echo's error handler. The error handler does not override an already-set content-type, nor the response code (if already written to the underlying ResponseWriter), so error responses looked really weird. Eg you could get a code 200, content-type: text/html, with a json body.

This PR scraps that, and uses an implemtation really similar to what `templ.Handler` does, which is to allocate a byte buffer and render the component to that. This plays nice with the error handler and doesn't return any nonsense.