### PR TITLE
feat: add `-o` flag to override the output file for a single input file

### DIFF
--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -13,6 +13,7 @@ import (
 
 type Arguments struct {
 	FileName                        string
+	OutputFileName                  string
 	ToStdout                        bool
 	Path                            string
 	Watch                           bool

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -68,9 +68,14 @@ Args:
     Generates code for all files in path. (default .)
   -f <file>
     Optionally generates code for a single file, e.g. -f header.templ
+  -o <file>
+    Optionally overrides the output file for a single file.
+    Only applicable when -f is used.
+    Not compatible with -stdout.
   -stdout
     Prints to stdout instead of writing generated files to the filesystem.
     Only applicable when -f is used.
+    Not compatible with -o.
   -sourceMapVisualisations
     Set to true to generate HTML files to visualise the templ code and its corresponding Go code.
   -include-version
@@ -123,6 +128,7 @@ func generateCmd(w io.Writer, args []string) (code int) {
 	fileNameFlag := cmd.String("f", "", "")
 	pathFlag := cmd.String("path", ".", "")
 	toStdoutFlag := cmd.Bool("stdout", false, "")
+	outputFileNameFlag := cmd.String("o", "", "")
 	sourceMapVisualisationsFlag := cmd.Bool("source-map-visualisations", false, "")
 	includeVersionFlag := cmd.Bool("include-version", true, "")
 	includeTimestampFlag := cmd.Bool("include-timestamp", false, "")
@@ -160,6 +166,7 @@ func generateCmd(w io.Writer, args []string) (code int) {
 	}()
 	err = generatecmd.Run(ctx, w, generatecmd.Arguments{
 		FileName:                        *fileNameFlag,
+		OutputFileName:                  *outputFileNameFlag,
 		Path:                            *pathFlag,
 		ToStdout:                        *toStdoutFlag,
 		Watch:                           *watchFlag,


### PR DESCRIPTION
While this could be seen as redundant given the existing flag `-stdout`, redirecting stdout is difficult in some environments such as Bazel (https://github.com/bazelbuild/bazel/issues/5511).

### Expected behaviour
Starting point:
```shell
$ ls
foo.templ  go.mod  go.sum out/
$ cat foo.templ 
$ cat go.mod 
module foo

go 1.22.2

require github.com/a-h/templ v0.2.680 // indirect
```
New behaviour:
* `templ generate -f foo.templ -o bar_templ.go` generates `bar_templ.go`.
* More interestingly for Bazel, `templ generate -f foo.templ -o out/bar_templ.go` generates `out/foo_templ.go`.
* Setting `-o` without `-f` returns an error stating the missing requirement.
* Simultaneously setting `-o` and `-stdout` returns an error citing the incompatibility.
* Setting an output filename that doesn't end in `_templ.go` returns an error.