### PR TITLE
feat: preserve indentation of multiline go string literals

### DIFF
--- a/parser/v2/formattestdata/multiline_string_literal_indentation_preserved.txt
+++ b/parser/v2/formattestdata/multiline_string_literal_indentation_preserved.txt
@@ -1,0 +1,40 @@
+-- in --
+package main
+
+templ x() {
+	@something(`Hi
+some cool text
+
+foo 
+
+bar
+
+		`)
+	@something(`
+		something
+				`,
+	`
+				something
+				`,
+		)
+}
+-- out --
+package main
+
+templ x() {
+	@something(`Hi
+some cool text
+
+foo 
+
+bar
+
+		`)
+	@something(`
+		something
+				`,
+		`
+				something
+				`,
+	)
+}

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -194,21 +194,6 @@ func (exp TemplateFileGoExpression) Write(w io.Writer, indent int) error {
 	return err
 }
 
-//nolint:unused // This could be useful.
-func writeLinesIndented(w io.Writer, level int, s string) (err error) {
-	indent := strings.Repeat("\t", level)
-	lines := strings.Split(s, "\n")
-	indented := strings.Join(lines, "\n"+indent)
-	if _, err = io.WriteString(w, indent); err != nil {
-		return err
-	}
-	_, err = io.WriteString(w, indented)
-	if err != nil {
-		return
-	}
-	return
-}
-
 func writeIndent(w io.Writer, level int, s ...string) (err error) {
 	indent := strings.Repeat("\t", level)
 	if _, err = io.WriteString(w, indent); err != nil {


### PR DESCRIPTION
Fixes #743 

The solution to this was a bit odd. I thought it would be more straight forward but no!

Essentially, I allow go fmt to format the code, then I indent everything by one, then format again. If go fmt removes the line then we are safe to auto-indent, but if the new indentation is preserved then we should leave it be.

Open to other solutions.