### PR TITLE
fix: docs tailwindcss setup option to use settings instead int_options

### DIFF
--- a/docs/docs/09-commands-and-tools/02-ide-support.md
+++ b/docs/docs/09-commands-and-tools/02-ide-support.md
@@ -117,7 +117,13 @@ lspconfig.tailwindcss.setup({
     on_attach = on_attach,
     capabilities = capabilities,
     filetypes = { "templ", "astro", "javascript", "typescript", "react" },
-    init_options = { userLanguages = { templ = "html" } },
+    settings = {
+      tailwindCSS = {
+        includeLanguages = {
+          templ = "html",
+        },
+      },
+    },
 })
 ```
 


### PR DESCRIPTION
This fix based on issue: #819 