### PR TITLE
fix(docs): add missing <p> content ("Text")

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -138,7 +138,7 @@ It's possible to spread any variable of type `templ.Attributes`. `templ.Attribut
 
 ```templ
 templ component(shouldBeUsed bool, attrs templ.Attributes) {
-  <p { attrs... }></p>
+  <p { attrs... }>Text</p>
   <hr
     if shouldBeUsed {
       { attrs... }


### PR DESCRIPTION
As example result `<p>` content is "Text".