### PR TITLE
feat: add support for lazy generation

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -98,6 +98,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 		cmd.Args.GenerateSourceMapVisualisations,
 		cmd.Args.KeepOrphanedFiles,
 		cmd.Args.FileWriter,
+		cmd.Args.Lazy,
 	)
 
 	// If we're processing a single file, don't bother setting up the channels/multithreaing.
@@ -183,6 +184,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 			cmd.Args.GenerateSourceMapVisualisations,
 			cmd.Args.KeepOrphanedFiles,
 			cmd.Args.FileWriter,
+			cmd.Args.Lazy,
 		)
 		errorCount.Store(0)
 		if err := watcher.WalkFiles(ctx, cmd.Args.Path, events); err != nil {

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -26,6 +26,7 @@ type Arguments struct {
 	// PPROFPort is the port to run the pprof server on.
 	PPROFPort         int
 	KeepOrphanedFiles bool
+	Lazy              bool
 }
 
 func Run(ctx context.Context, log *slog.Logger, args Arguments) (err error) {

--- a/cmd/templ/generatecmd/test-eventhandler/eventhandler_test.go
+++ b/cmd/templ/generatecmd/test-eventhandler/eventhandler_test.go
@@ -43,7 +43,7 @@ func TestErrorLocationMapping(t *testing.T) {
 
 	slog := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	var fw generatecmd.FileWriterFunc
-	fseh := generatecmd.NewFSEventHandler(slog, ".", false, []generator.GenerateOpt{}, false, false, fw)
+	fseh := generatecmd.NewFSEventHandler(slog, ".", false, []generator.GenerateOpt{}, false, false, fw, false)
 	for _, test := range tests {
 		// The raw files cannot end in .templ because they will cause the generator to fail. Instead,
 		// we create a tmp file that ends in .templ only for the duration of the test.

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -169,6 +169,8 @@ Args:
     If present, the command will issue a reload event to the proxy 127.0.0.1:7331, or use proxyport and proxybind to specify a different address.
   -w
     Number of workers to use when generating code. (default runtime.NumCPUs)
+  -lazy
+    Only generate .go files if the source .templ file is newer.	
   -pprof
     Port to run the pprof server on.
   -keep-orphaned-files
@@ -215,6 +217,7 @@ func generateCmd(stdout, stderr io.Writer, args []string) (code int) {
 	keepOrphanedFilesFlag := cmd.Bool("keep-orphaned-files", false, "")
 	verboseFlag := cmd.Bool("v", false, "")
 	logLevelFlag := cmd.String("log-level", "info", "")
+	lazyFlag := cmd.Bool("lazy", false, "")
 	helpFlag := cmd.Bool("help", false, "")
 	err := cmd.Parse(args)
 	if err != nil {
@@ -259,6 +262,7 @@ func generateCmd(stdout, stderr io.Writer, args []string) (code int) {
 		IncludeTimestamp:                *includeTimestampFlag,
 		PPROFPort:                       *pprofPortFlag,
 		KeepOrphanedFiles:               *keepOrphanedFilesFlag,
+		Lazy:                            *lazyFlag,
 	})
 	if err != nil {
 		color.New(color.FgRed).Fprint(stderr, "(✗) ")

--- a/docs/docs/04-core-concepts/02-template-generation.md
+++ b/docs/docs/04-core-concepts/02-template-generation.md
@@ -60,6 +60,8 @@ Args:
     If present, the command will issue a reload event to the proxy 127.0.0.1:7331, or use proxyport and proxybind to specify a different address.
   -w
     Number of workers to use when generating code. (default runtime.NumCPUs)
+  -lazy
+    Only generate .go files if the source .templ file is newer.	
   -pprof
     Port to run the pprof server on.
   -keep-orphaned-files

--- a/docs/docs/09-commands-and-tools/01-cli.md
+++ b/docs/docs/09-commands-and-tools/01-cli.md
@@ -51,6 +51,8 @@ Args:
     The address the proxy will listen on. (default 127.0.0.1)
   -w
     Number of workers to use when generating code. (default runtime.NumCPUs)
+  -lazy
+    Only generate .go files if the source .templ file is newer.	
   -pprof
     Port to run the pprof server on.
   -keep-orphaned-files


### PR DESCRIPTION
The `templ generate` command generates `.go` files from `.templ` files. When the `.go` file is newer than the `.templ` file it indicates that the `.templ` has not been updated since the `.go` file was generated. This means that the `.go` file is still valid and does not need to be generated again. *This ignores users manually editing the generated `.go` files, but there is usually not a good reason to do this.* 

This pull request contains a proposal to only generate the `.go` file if it is older than its source `.templ` file. This functionality was put behind a `--lazy` CLI flag to maintain backwards compatibility. 

~Aerek