### PR TITLE
feat(lsp): add workspace folder initialization

### DIFF
--- a/cmd/templ/testproject/testdata/remoteChild.templ
+++ b/cmd/templ/testproject/testdata/remoteChild.templ
@@ -1,0 +1,5 @@
+package main
+
+templ Remote() {
+	<p>This is remote content</p>
+}

--- a/cmd/templ/testproject/testdata/remoteParent.templ
+++ b/cmd/templ/testproject/testdata/remoteParent.templ
@@ -1,0 +1,9 @@
+package main
+
+templ RemoteInclusionTest() {
+	@Remote
+}
+
+templ Remote2() {
+	@Remote
+}


### PR DESCRIPTION
Fixes #911 

- Added logic to walk through workspace folders and initialize templ files.
- Logs warnings when source maps are not found in cache.
- Parses templates and sets source map cache contents.
- Handles errors during file reading, template parsing, and generation.

works on #911 