### PR TITLE
fix(fmt): Preserve multiple newlines between elements (#374)

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -471,7 +471,7 @@ func addTrailingSpaceAndValidate(start parse.Position, e Element, pi *parse.Inpu
 	if err != nil {
 		return e, false, err
 	}
-	e.TrailingSpace, err = NewTrailingSpace(ws)
+	e.TrailingSpace, err = NewTrailingSpace(ws, true)
 	if err != nil {
 		return e, false, err
 	}

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -1539,6 +1539,43 @@ func TestElementParser(t *testing.T) {
 			},
 		},
 		{
+			name: "element: with multiple newlines, should collapse to two",
+			input: `<div>
+	<span></span>
+
+
+
+	<span></span>
+</div>`,
+			expected: Element{
+				Name: "div",
+				NameRange: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 4, Line: 0, Col: 4},
+				},
+				IndentChildren: true,
+				Children: []Node{
+					Whitespace{Value: "\n\t"},
+					Element{
+						Name: "span",
+						NameRange: Range{
+							From: Position{Index: 8, Line: 1, Col: 2},
+							To:   Position{Index: 12, Line: 1, Col: 6},
+						},
+						TrailingSpace: SpaceVerticalDouble,
+					},
+					Element{
+						Name: "span",
+						NameRange: Range{
+							From: Position{Index: 26, Line: 5, Col: 2},
+							To:   Position{Index: 30, Line: 5, Col: 6},
+						},
+						TrailingSpace: SpaceVertical,
+					},
+				},
+			},
+		},
+		{
 			name: "element: can contain text that starts with for",
 			input: `<div>for which any 
 amount is charged</div>`,

--- a/parser/v2/formattestdata/element_double_newline_is_preserved.txt
+++ b/parser/v2/formattestdata/element_double_newline_is_preserved.txt
@@ -1,0 +1,28 @@
+-- in --
+package main
+
+templ x() {
+  <div>
+    <span>Hello
+
+    World
+    </span>
+
+
+
+    <span>Foo Bar </span>
+  </div>
+}
+-- out --
+package main
+
+templ x() {
+	<div>
+		<span>
+			Hello
+			World
+		</span>
+
+		<span>Foo Bar </span>
+	</div>
+}

--- a/parser/v2/gocodeparser.go
+++ b/parser/v2/gocodeparser.go
@@ -36,7 +36,7 @@ var goCode = parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
 	if err != nil {
 		return r, false, err
 	}
-	r.TrailingSpace, err = NewTrailingSpace(ws)
+	r.TrailingSpace, err = NewTrailingSpace(ws, true)
 	if err != nil {
 		return r, false, err
 	}

--- a/parser/v2/stringexpressionparser.go
+++ b/parser/v2/stringexpressionparser.go
@@ -30,7 +30,7 @@ var stringExpression = parse.Func(func(pi *parse.Input) (n Node, ok bool, err er
 	if err != nil {
 		return r, false, err
 	}
-	r.TrailingSpace, err = NewTrailingSpace(ws)
+	r.TrailingSpace, err = NewTrailingSpace(ws, false)
 	if err != nil {
 		return r, false, err
 	}

--- a/parser/v2/textparser.go
+++ b/parser/v2/textparser.go
@@ -35,7 +35,7 @@ var textParser = parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
 	if err != nil {
 		return t, false, err
 	}
-	t.TrailingSpace, err = NewTrailingSpace(ws)
+	t.TrailingSpace, err = NewTrailingSpace(ws, false)
 	if err != nil {
 		return t, false, err
 	}

--- a/parser/v2/textparser_test.go
+++ b/parser/v2/textparser_test.go
@@ -80,7 +80,7 @@ func TestTextParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "Multiline text is colected line by line",
+			name:  "Multiline text is collected line by line",
 			input: "Line 1\nLine 2",
 			expected: Text{
 				Value: "Line 1",
@@ -92,8 +92,20 @@ func TestTextParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "Multiline text is colected line by line (Windows)",
+			name:  "Multiline text is collected line by line (Windows)",
 			input: "Line 1\r\nLine 2",
+			expected: Text{
+				Value: "Line 1",
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 6, Line: 0, Col: 6},
+				},
+				TrailingSpace: "\n",
+			},
+		},
+		{
+			name:  "Multiline text with multiple newlines is collected line by line",
+			input: "Line 1\n\n\n\nLine 2",
 			expected: Text{
 				Value: "Line 1",
 				Range: Range{


### PR DESCRIPTION
Preserves multiple lines between elements, to allow organizing code better.
For reference and discussion, see #374.

`templ fmt` [is inconsistent with itself](https://github.com/a-h/templ/issues/374#issuecomment-2027357343), sometimes preserving newlines (collapsing) and sometimes now.
This aligns `templ fmt` with `gofmt`, which also preserves newlines (by collapsing multiple standalone newlines into one), which `templ fmt` also does in go functions.