### PR TITLE
Add Formatting Fail Flag for CI Use

### DIFF
--- a/cmd/templ/fmtcmd/main.go
+++ b/cmd/templ/fmtcmd/main.go
@@ -138,7 +138,6 @@ func writeToFile(fileName, tgt string) error {
 	return atomic.WriteFile(fileName, bytes.NewBufferString(tgt))
 }
 
-// TODO DO CHANGE TRACKING HERE
 func format(write writer, read reader, writeIfUnchanged bool) (err error, fileChanged bool) {
 	fileName, src, err := read()
 	if err != nil {

--- a/cmd/templ/fmtcmd/main_test.go
+++ b/cmd/templ/fmtcmd/main_test.go
@@ -84,6 +84,7 @@ func TestFormat(t *testing.T) {
 			Files: []string{
 				tp.testFiles["a.templ"].name,
 			},
+			FailIfChanged: false,
 		}); err != nil {
 			t.Fatalf("failed to run format command: %v", err)
 		}
@@ -101,6 +102,7 @@ func TestFormat(t *testing.T) {
 			Files: []string{
 				tp.testFiles["a.templ"].name,
 			},
+			FailIfChanged: false,
 		}); err != nil {
 			t.Fatalf("failed to run format command: %v", err)
 		}
@@ -109,6 +111,52 @@ func TestFormat(t *testing.T) {
 			t.Fatalf("failed to read file: %v", err)
 		}
 		if diff := cmp.Diff(tp.testFiles["a.templ"].expected, string(data)); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("fails when fail flag used and change occurs", func(t *testing.T) {
+		tp, err := setupProjectDir()
+		if err != nil {
+			t.Fatalf("failed to setup project dir: %v", err)
+		}
+		defer tp.cleanup()
+		if err = Run(log, nil, nil, Arguments{
+			Files: []string{
+				tp.testFiles["a.templ"].name,
+			},
+			FailIfChanged: true,
+		}); err == nil {
+			t.Fatal("command should have exited with an error and did not")
+		}
+		data, err := os.ReadFile(tp.testFiles["a.templ"].name)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+		if diff := cmp.Diff(tp.testFiles["a.templ"].expected, string(data)); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("passes when fail flag used and no change occurs", func(t *testing.T) {
+		tp, err := setupProjectDir()
+		if err != nil {
+			t.Fatalf("failed to setup project dir: %v", err)
+		}
+		defer tp.cleanup()
+		if err = Run(log, nil, nil, Arguments{
+			Files: []string{
+				tp.testFiles["c.templ"].name,
+			},
+			FailIfChanged: true,
+		}); err != nil {
+			t.Fatalf("failed to run format command: %v", err)
+		}
+		data, err := os.ReadFile(tp.testFiles["c.templ"].name)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+		if diff := cmp.Diff(tp.testFiles["c.templ"].expected, string(data)); diff != "" {
 			t.Error(diff)
 		}
 	})

--- a/cmd/templ/fmtcmd/testdata.txtar
+++ b/cmd/templ/fmtcmd/testdata.txtar
@@ -22,13 +22,33 @@ templ b() {
 	<div><p>B
 </p></div>
 }
--- a.templ --
+-- b.templ --
 package test
 
 templ b() {
 	<div>
 		<p>
 			B
+		</p>
+	</div>
+}
+-- c.templ --
+package test
+
+templ c() {
+	<div>
+		<p>
+			C
+		</p>
+	</div>
+}
+-- c.templ --
+package test
+
+templ c() {
+	<div>
+		<p>
+			C
 		</p>
 	</div>
 }

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -297,7 +297,7 @@ Args:
   -log-level
     Set log verbosity level. (default "info", options: "debug", "info", "warn", "error")
   -w
-    Number of workers to use when formatting code. (default runtime.NumCPUs).\
+    Number of workers to use when formatting code. (default runtime.NumCPUs).
   -fail-if-changed
     Fails with an error exit code if files are changed for use in CI.
   -help

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -298,7 +298,7 @@ Args:
     Set log verbosity level. (default "info", options: "debug", "info", "warn", "error")
   -w
     Number of workers to use when formatting code. (default runtime.NumCPUs).
-  -fail-if-changed
+  -fail
     Fails with an error exit code if files are changed for use in CI.
   -help
     Print help and exit.
@@ -310,7 +310,7 @@ func fmtCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 	workerCountFlag := cmd.Int("w", runtime.NumCPU(), "")
 	verboseFlag := cmd.Bool("v", false, "")
 	logLevelFlag := cmd.String("log-level", "info", "")
-	failIfChanged := cmd.Bool("fail-if-changed", false, "")
+	failIfChanged := cmd.Bool("fail", false, "")
 	stdoutFlag := cmd.Bool("stdout", false, "")
 	stdinFilepath := cmd.String("stdin-filepath", "", "")
 	err := cmd.Parse(args)

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -297,7 +297,9 @@ Args:
   -log-level
     Set log verbosity level. (default "info", options: "debug", "info", "warn", "error")
   -w
-    Number of workers to use when formatting code. (default runtime.NumCPUs).
+    Number of workers to use when formatting code. (default runtime.NumCPUs).\
+  -fail-if-changed
+    Fails with an error exit code if files are changed for use in CI.
   -help
     Print help and exit.
 `
@@ -308,6 +310,7 @@ func fmtCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 	workerCountFlag := cmd.Int("w", runtime.NumCPU(), "")
 	verboseFlag := cmd.Bool("v", false, "")
 	logLevelFlag := cmd.String("log-level", "info", "")
+	failIfChanged := cmd.Bool("fail-if-changed", false, "")
 	stdoutFlag := cmd.Bool("stdout", false, "")
 	stdinFilepath := cmd.String("stdin-filepath", "", "")
 	err := cmd.Parse(args)
@@ -327,6 +330,7 @@ func fmtCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 		Files:         cmd.Args(),
 		WorkerCount:   *workerCountFlag,
 		StdinFilepath: *stdinFilepath,
+		FailIfChanged: *failIfChanged,
 	})
 	if err != nil {
 		return 1

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -299,7 +299,7 @@ Args:
   -w
     Number of workers to use when formatting code. (default runtime.NumCPUs).
   -fail
-    Fails with an error exit code if files are changed for use in CI.
+    Fails with exit code 1 if files are changed. (e.g. in CI)
   -help
     Print help and exit.
 `

--- a/cmd/templ/processor/processor.go
+++ b/cmd/templ/processor/processor.go
@@ -10,12 +10,13 @@ import (
 )
 
 type Result struct {
-	FileName string
-	Duration time.Duration
-	Error    error
+	FileName    string
+	Duration    time.Duration
+	Error       error
+	ChangesMade bool
 }
 
-func Process(dir string, f func(fileName string) error, workerCount int, results chan<- Result) {
+func Process(dir string, f func(fileName string) (error, bool), workerCount int, results chan<- Result) {
 	templates := make(chan string)
 	go func() {
 		defer close(templates)
@@ -56,7 +57,7 @@ func FindTemplates(srcPath string, output chan<- string) (err error) {
 	})
 }
 
-func ProcessChannel(templates <-chan string, dir string, f func(fileName string) error, workerCount int, results chan<- Result) {
+func ProcessChannel(templates <-chan string, dir string, f func(fileName string) (error, bool), workerCount int, results chan<- Result) {
 	defer close(results)
 	var wg sync.WaitGroup
 	wg.Add(workerCount)
@@ -65,10 +66,13 @@ func ProcessChannel(templates <-chan string, dir string, f func(fileName string)
 			defer wg.Done()
 			for sourceFileName := range templates {
 				start := time.Now()
+				outErr, outChanged := f(sourceFileName)
 				results <- Result{
-					FileName: sourceFileName,
-					Error:    f(sourceFileName),
-					Duration: time.Since(start),
+					FileName:    sourceFileName,
+					Error:       outErr,
+					Duration:    time.Since(start),
+					ChangesMade: outChanged,
+					// TODO get this working
 				}
 			}
 		}()

--- a/cmd/templ/processor/processor.go
+++ b/cmd/templ/processor/processor.go
@@ -72,7 +72,6 @@ func ProcessChannel(templates <-chan string, dir string, f func(fileName string)
 					Error:       outErr,
 					Duration:    time.Since(start),
 					ChangesMade: outChanged,
-					// TODO get this working
 				}
 			}
 		}()

--- a/docs/docs/09-commands-and-tools/01-cli.md
+++ b/docs/docs/09-commands-and-tools/01-cli.md
@@ -87,6 +87,13 @@ templ fmt .
 templ fmt
 ```
 
+Alternatively, you can run `fmt` in CI to ensure that invalidly formatted templatess do not pass CI. This will cause the command
+to exit with unix error-code `1` if any templates needed to be modified.
+
+```
+templ fmt -fail-if-changed .
+```
+
 ## Language Server for IDE integration
 
 `templ lsp` provides a Language Server Protocol (LSP) implementation to support IDE integrations.

--- a/docs/docs/09-commands-and-tools/01-cli.md
+++ b/docs/docs/09-commands-and-tools/01-cli.md
@@ -91,7 +91,7 @@ Alternatively, you can run `fmt` in CI to ensure that invalidly formatted templa
 to exit with unix error-code `1` if any templates needed to be modified.
 
 ```
-templ fmt -fail-if-changed .
+templ fmt -fail .
 ```
 
 ## Language Server for IDE integration


### PR DESCRIPTION
A common use with linters and formatters is checking in CI and failing if the formatter required any changed. This ensures that branches are never merged without the formatter being run.

This PR implements this functionality by tracking the number of files changed, and allowing the user to return an error exit code if `-fail` is provided, subsequently failing the CI job if formatting was not done before commit.

This PR also has the side benefit of providing additional user situational awareness as it now prints the number of changed files on every format run, even if the CI-fail flag is not used.

After merge, users can add the following to their CI to validate template formatting.
```
templ fmt -fail .
```

## Results

`fmt`'s help now looks like this:

```
./templ fmt --help
usage: templ fmt [<args> ...]

Format all files in directory:

  templ fmt .

Format stdin to stdout:

  templ fmt < header.templ

Format file or directory to stdout:

  templ fmt -stdout FILE

Args:
  -stdout
    Prints to stdout instead of in-place format
  -stdin-filepath
    Provides the formatter with filepath context when using -stdout.
    Required for organising imports.
  -v
    Set log verbosity level to "debug". (default "info")
  -log-level
    Set log verbosity level. (default "info", options: "debug", "info", "warn", "error")
  -w
    Number of workers to use when formatting code. (default runtime.NumCPUs).
  -fail
    Fails with an error exit code if files are changed for use in CI.
  -help
    Print help and exit.
```

A normal run now looks like this (note the `changed` field) if no changes made.

```
./templ fmt .
(✓) Format Complete [ count=4 errors=0 changed=0 duration=11.045765ms ]
```


A normal run now looks like this (note the `changed` field) if changes are made.

```
./templ fmt .
(✓) Format Complete [ count=4 errors=0 changed=1 duration=11.045765ms ]
```

The new flag run now looks like this, if changes are made.

```
./templ fmt -fail .
(✗) Templates were valid but not properly formatted [ count=4 changed=1 errors=0 duration=19.007765ms ]
```
In the above case, the unix exit code is also `1` instead of the normal `0`.
