### PR TITLE
parser: fix memory leak in goexpression.Func (fixes #916)

### DIFF
--- a/parser/v2/goexpression/parse.go
+++ b/parser/v2/goexpression/parse.go
@@ -256,7 +256,7 @@ func Func(content string) (name, expr string, err error) {
 			err = errors.New("parser error: function identifier")
 			return false
 		}
-		expr = src[start:end]
+		expr = strings.Clone(src[start:end])
 		name = fn.Name.Name
 		return false
 	})


### PR DESCRIPTION
Do not let whole contents of `src` escape to heap.
Fixes #916 