### PR TITLE
fix: example flake syntax error

### DIFF
--- a/docs/docs/02-quick-start/01-installation.md
+++ b/docs/docs/02-quick-start/01-installation.md
@@ -61,23 +61,23 @@ This flake exposes an overlay, so you can add it to your own Flake and/or NixOS 
     });
     templ = system: inputs.templ.packages.${system}.templ;
   in {
-    packages = forAllSystems ({ pkgs, system }): {
+    packages = forAllSystems ({ pkgs, system }: {
       myNewPackage = pkgs.buildGoModule {
         ...
         preBuild = ''
           ${templ system}/bin/templ generate
         '';
       };
-    };
+    });
 
-    devShell = forAllSystems ({ pkgs, system }):
+    devShell = forAllSystems ({ pkgs, system }:
       pkgs.mkShell {
         buildInputs = with pkgs; [
           go
           (templ system)
         ];
       };
-  };
+  });
 }
 ```
 


### PR DESCRIPTION
The example flake had at least two syntax errors which have been fixed. The example flake cannot be ran by itself so there might be more syntax errors.

I can replace it with a flake that actually works and can just be copied and pasted into a project if that is preferred.


The syntax errors were that the parenthesis were in the incorrect place.