### PR TITLE
cmd/templ/lspcmd/proxy: append ';templ' in initialize client info

### DIFF
--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -209,6 +209,7 @@ func (p *Server) parseTemplate(ctx context.Context, uri uri.URI, templateText st
 func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (result *lsp.InitializeResult, err error) {
 	p.Log.Info("client -> server: Initialize")
 	defer p.Log.Info("client -> server: Initialize end")
+	params.ClientInfo.Name += ";templ" // e.g. "Visual Studio Code;templ"
 	result, err = p.Target.Initialize(ctx, params)
 	if err != nil {
 		p.Log.Error("Initialize failed", zap.Error(err))


### PR DESCRIPTION
This allows gopls to recognize gopls instances serving for templ and count separately in go telemetry data processing.
