### PR TITLE
Add proxyopen flag

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -374,8 +374,10 @@ func (cmd *Generate) StartProxy(ctx context.Context) (p *proxy.Handler, err erro
 			)
 			time.Sleep(d)
 		}
-		if err := browser.OpenURL(p.URL); err != nil {
-			cmd.Log.Error("Failed to open browser", slog.Any("error", err))
+		if cmd.Args.ProxyOpen {
+			if err := browser.OpenURL(p.URL); err != nil {
+				cmd.Log.Error("Failed to open browser", slog.Any("error", err))
+			}
 		}
 	}()
 	return p, nil

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -17,6 +17,7 @@ type Arguments struct {
 	Command                         string
 	ProxyBind                       string
 	ProxyPort                       int
+	ProxyOpen                       bool
 	Proxy                           string
 	NotifyProxy                     bool
 	WorkerCount                     int

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -211,6 +211,7 @@ func generateCmd(stdout, stderr io.Writer, args []string) (code int) {
 	proxyFlag := cmd.String("proxy", "", "")
 	proxyPortFlag := cmd.Int("proxyport", 7331, "")
 	proxyBindFlag := cmd.String("proxybind", "127.0.0.1", "")
+	proxyOpenFlag := cmd.Bool("proxyopen", true, "")
 	notifyProxyFlag := cmd.Bool("notify-proxy", false, "")
 	workerCountFlag := cmd.Int("w", runtime.NumCPU(), "")
 	pprofPortFlag := cmd.Int("pprof", 0, "")
@@ -255,6 +256,7 @@ func generateCmd(stdout, stderr io.Writer, args []string) (code int) {
 		Proxy:                           *proxyFlag,
 		ProxyPort:                       *proxyPortFlag,
 		ProxyBind:                       *proxyBindFlag,
+		ProxyOpen:                       *proxyOpenFlag,
 		NotifyProxy:                     *notifyProxyFlag,
 		WorkerCount:                     *workerCountFlag,
 		GenerateSourceMapVisualisations: *sourceMapVisualisationsFlag,


### PR DESCRIPTION
This adds a flag so that you can add `--proxyopen=false` to disable automatically opening the proxy url in a new browser window when the watcher starts. 

I tried to make it so the current behavior is the default, and you can opt into disabling it. 