### PR TITLE
feat: `ResetContext` func to allow resetting initialized context

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -550,7 +550,7 @@ func (v *contextValue) hasClassBeenRendered(s string) (ok bool) {
 
 // InitializeContext initializes context used to store internal state used during rendering.
 func InitializeContext(ctx context.Context) context.Context {
-	if _, ok := ctx.Value(contextKey).(*contextValue); ok {
+	if v, ok := ctx.Value(contextKey).(*contextValue); ok && v != nil {
 		return ctx
 	}
 	v := &contextValue{}
@@ -558,9 +558,14 @@ func InitializeContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// ResetContext resets context to prevent further usage of context state.
+func ResetContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKey, nil)
+}
+
 func getContext(ctx context.Context) (context.Context, *contextValue) {
 	v, ok := ctx.Value(contextKey).(*contextValue)
-	if !ok {
+	if !ok || v == nil {
 		ctx = InitializeContext(ctx)
 		v = ctx.Value(contextKey).(*contextValue)
 	}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -569,3 +569,28 @@ func TestNonce(t *testing.T) {
 		}
 	})
 }
+
+func TestContextManipulations(t *testing.T) {
+	t.Run("reinitializing an already initialized context returns the same instance", func(t *testing.T) {
+		ctx := templ.InitializeContext(context.Background())
+		if ctx != templ.InitializeContext(ctx) {
+			t.Error("expected reinitialization of an already initialized context to return the same instance")
+		}
+	})
+
+	t.Run("reset context allows reinitialization to create a new instance", func(t *testing.T) {
+		ctx := templ.InitializeContext(context.Background())
+		resetCtx := templ.ResetContext(ctx)
+		if ctx == templ.InitializeContext(resetCtx) {
+			t.Error("expected reinitialization of a reset context to return a new instance")
+		}
+	})
+
+	t.Run("reset context clears existing state", func(t *testing.T) {
+		ctx := templ.WithNonce(context.Background(), "abc123")
+		ctx = templ.ResetContext(ctx)
+		if templ.GetNonce(ctx) != "" {
+			t.Error("expected reset context to have an empty state, but found a non-empty nonce")
+		}
+	})
+}


### PR DESCRIPTION
The feature allows a context to be reset before reusing it in multiple go-routines ([see the issue](https://github.com/a-h/templ/issues/977)). 

An alternative solution would be to always create a new context, which would be overkill for 99.9% of single-threaded use cases.