### PR TITLE
docs: correct documentation for source-map-visualisations argument

### DIFF
--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -149,7 +149,7 @@ Args:
   -stdout
     Prints to stdout instead of writing generated files to the filesystem.
     Only applicable when -f is used.
-  -sourceMapVisualisations
+  -source-map-visualisations
     Set to true to generate HTML files to visualise the templ code and its corresponding Go code.
   -include-version
     Set to false to skip inclusion of the templ version in the generated code. (default true)

--- a/docs/docs/04-core-concepts/02-template-generation.md
+++ b/docs/docs/04-core-concepts/02-template-generation.md
@@ -40,7 +40,7 @@ Args:
   -stdout
     Prints to stdout instead of writing generated files to the filesystem.
     Only applicable when -f is used.
-  -sourceMapVisualisations
+  -source-map-visualisations
     Set to true to generate HTML files to visualise the templ code and its corresponding Go code.
   -include-version
     Set to false to skip inclusion of the templ version in the generated code. (default true)

--- a/docs/docs/09-commands-and-tools/01-cli.md
+++ b/docs/docs/09-commands-and-tools/01-cli.md
@@ -33,7 +33,7 @@ Args:
     Generates code for all files in path. (default .)
   -f <file>
     Optionally generates code for a single file, e.g. -f header.templ
-  -sourceMapVisualisations
+  -source-map-visualisations
     Set to true to generate HTML files to visualise the templ code and its corresponding Go code.
   -include-version
     Set to false to skip inclusion of the templ version in the generated code. (default true)


### PR DESCRIPTION
The documentation of the `templ generate` command refers to the `-sourceMapVisualisations` argument. Using it generates the following error.

```bash
$ templ generate -sourceMapVisualisations .
flag provided but not defined: -sourceMapVisualisations
```

However, using the more conventionally named `-source-map-visualisations` argument successfully generates HTML files to visualize the templ code and its corresponding Go code, as shown below.

```bash
$ templ generate -source-map-visualisations
(✓) Complete [ updates=302 duration=520.239583ms ]
```

To resolve this, we can update the documentation to refer to the `-source-map-visualisations` argument instead.

