### PR TITLE
fix: remove repeated error messages (#1011)

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -210,7 +210,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 				defer func() { <-sem }()
 				goUpdated, textUpdated, err := fseh.HandleEvent(ctx, event)
 				if err != nil {
-					cmd.Log.Error("Event handler failed", slog.Any("error", err))
+					// cmd.Log.Error("Event handler failed", slog.Any("error", err))
 					errs <- err
 				}
 				if goUpdated || textUpdated {

--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -210,7 +210,6 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 				defer func() { <-sem }()
 				goUpdated, textUpdated, err := fseh.HandleEvent(ctx, event)
 				if err != nil {
-					// cmd.Log.Error("Event handler failed", slog.Any("error", err))
 					errs <- err
 				}
 				if goUpdated || textUpdated {

--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -143,11 +143,6 @@ func (h *FSEventHandler) HandleEvent(ctx context.Context, event fsnotify.Event) 
 	start := time.Now()
 	goUpdated, textUpdated, diag, err := h.generate(ctx, event.Name)
 	if err != nil {
-		// h.Log.Error(
-		// 	"Error generating code",
-		// 	slog.String("file", event.Name),
-		// 	slog.Any("error", err),
-		// )
 		h.SetError(event.Name, true)
 		return goUpdated, textUpdated, fmt.Errorf("failed to generate code for %q: %w", event.Name, err)
 	}

--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -143,11 +143,11 @@ func (h *FSEventHandler) HandleEvent(ctx context.Context, event fsnotify.Event) 
 	start := time.Now()
 	goUpdated, textUpdated, diag, err := h.generate(ctx, event.Name)
 	if err != nil {
-		h.Log.Error(
-			"Error generating code",
-			slog.String("file", event.Name),
-			slog.Any("error", err),
-		)
+		// h.Log.Error(
+		// 	"Error generating code",
+		// 	slog.String("file", event.Name),
+		// 	slog.Any("error", err),
+		// )
 		h.SetError(event.Name, true)
 		return goUpdated, textUpdated, fmt.Errorf("failed to generate code for %q: %w", event.Name, err)
 	}


### PR DESCRIPTION
I think this is removes the repeated error messages. Let me know if I've missed anything.

Example:
```
templ generate
(✗) Error [ error=failed to generate code for <file_here>: <file_here> parsing error: <p>: close tag not found: line 4, col 0 ]
(✗) Command failed: generation completed with 1 errors
```


Closes https://github.com/a-h/templ/issues/1011