### PR TITLE
feat: imports grouping

### DIFF
--- a/cmd/templ/imports/testdata/groups.txtar
+++ b/cmd/templ/imports/testdata/groups.txtar
@@ -1,0 +1,22 @@
+-- fmt.templ --
+package test
+
+import (
+	"strings"
+	"fmt"
+
+	"strconv"
+)
+
+var _, _ = fmt.Print(strings.Contains(strconv.Quote("Hello"), ""))
+-- fmt.templ --
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"strconv"
+)
+
+var _, _ = fmt.Print(strings.Contains(strconv.Quote("Hello"), ""))

--- a/cmd/templ/imports/testdata/groupsmanynewlines.txtar
+++ b/cmd/templ/imports/testdata/groupsmanynewlines.txtar
@@ -1,0 +1,21 @@
+-- fmt.templ --
+package test
+
+import (
+	"fmt"
+
+
+	"strconv"
+)
+
+var _, _ = fmt.Print(strconv.Quote("Hello"))
+-- fmt.templ --
+package test
+
+import (
+	"fmt"
+
+	"strconv"
+)
+
+var _, _ = fmt.Print(strconv.Quote("Hello"))


### PR DESCRIPTION
This pr changes formatter to keep a new line between imports. For example, if you had such code:
```go
package main

import (
	"fmt"
	"strings"

	"strconv"
)

var _, _ = fmt.Print("")
var _ = strings.Index("", "")
var _ = strconv.Quote("")
```

It would remove the empty line, but now it doesn't.

closes #939