### PR TITLE
Fix live reload when go code in a template is changed

### DIFF
--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -106,7 +106,7 @@ func (h *FSEventHandler) HandleEvent(ctx context.Context, event fsnotify.Event) 
 	if !event.Has(fsnotify.Remove) && strings.HasSuffix(event.Name, "_templ.go") {
 		_, err = os.Stat(strings.TrimSuffix(event.Name, "_templ.go") + ".templ")
 		if !os.IsNotExist(err) {
-			return GenerateResult{}, err
+			return GenerateResult{GoUpdated: true}, err
 		}
 		// File is orphaned.
 		if h.keepOrphanedFiles {


### PR DESCRIPTION
Right now, if you take this file:

```
package templchecks

templ Reloading() {
  <div>
    {{ a := "foobar" }}
    Hello
    {a}
    { "spam" }
  </div>
}
```

And run the project in watch + cmd mode. Ex: `templ generate --watch --cmd="go run ./cmd/web"`

If I only change the `"foobar"` content, or the `"spam"` (essentially, any go code). Of even if I add an empty `templ` clause after. Then nothing will happen. Reloading the page manually will not show the change, the debug logs will not mention executing the command. (And with --proxy, no autoreload will happen).

If I then change the `Hello`, or any raw html part, then the reload & restart will happen, and I will see both changes when I reload (or auto-reload via --proxy) the page.

I believe the problem comes from the line I'm modifying.

An alternative fix (I think, not tested), is that if we leave the `if`,  the code flow would reach further down the file where GoUpdated gets set.

I really wish I could add a test, but it's not clear where to do that and the test are pretty complex, so it's unlikely they would match the style you expect. (Also, I've been doing Go for less than 2 days, so I'm not confortable yet).