### PR TITLE
refactor: don't generate a `type` attribute for `<script>` elements, update associated docs

### DIFF
--- a/docs/docs/03-syntax-and-usage/03-attributes.md
+++ b/docs/docs/03-syntax-and-usage/03-attributes.md
@@ -225,7 +225,7 @@ templ Button(text string) {
 ```
 
 ```html title="Output"
-<script type="text/javascript">
+<script>
  function __templ_withParameters_1056(a, b, c){console.log(a, b, c);}function __templ_withoutParameters_6bbf(){alert("hello");}
 </script>
 <button onclick="__templ_withParameters_1056("test","Say hello",123)" onmouseover="__templ_withoutParameters_6bbf()" type="button">

--- a/docs/docs/03-syntax-and-usage/12-script-templates.md
+++ b/docs/docs/03-syntax-and-usage/12-script-templates.md
@@ -6,7 +6,7 @@ Use standard `<script>` tags, and standard HTML attributes to run JavaScript on 
 
 ```templ
 templ body() {
-  <script type="text/javascript">
+  <script>
     function handleClick(event) {
       alert(event + ' clicked');
     }
@@ -49,7 +49,7 @@ HTML element `on*` attributes pass an event object to the function. To pass the 
 :::
 
 ```templ title="input.templ"
-<script type="text/javascript">
+<script>
 	function clickHandler(event, message) {
 		alert(message);
 		event.preventDefault();
@@ -61,7 +61,7 @@ HTML element `on*` attributes pass an event object to the function. To pass the 
 The output would be:
 
 ```html title="output.html"
-<script type="text/javascript">
+<script>
 	function clickHandler(event, message) {
 		alert(message);
 		event.preventDefault();
@@ -87,7 +87,7 @@ templ InitializeClientSideScripts(data CustomType) {
 This will output a `<script>` tag that calls the `functionToCall` function with the `Name` and `Age` properties of the `data` object.
 
 ```html title="output.html"
-<script type="text/javascript">
+<script>
   functionToCall("John", 42);
 </script>
 ```
@@ -169,7 +169,7 @@ var helloHandle = templ.NewOnceHandle()
 templ hello(label, name string) {
   // This script is only rendered once per HTTP request.
   @helloHandle.Once() {
-    <script type="text/javascript">
+    <script>
       function hello(name) {
         alert('Hello, ' + name + '!');
       }
@@ -177,7 +177,7 @@ templ hello(label, name string) {
   }
   <div>
     <input type="button" value={ label } data-name={ name }/>
-    <script type="text/javascript">
+    <script>
       // To prevent the variables from leaking into the global scope,
       // this script is wrapped in an IIFE (Immediately Invoked Function Expression).
       (() => {
@@ -213,7 +213,7 @@ var surrealHandle = templ.NewOnceHandle()
 
 templ hello(label, name string) {
   @helloHandle.Once() {
-    <script type="text/javascript">
+    <script>
       function hello(name) {
         alert('Hello, ' + name + '!');
       }
@@ -224,7 +224,7 @@ templ hello(label, name string) {
   }
   <div>
     <input type="button" value={ label } data-name={ name }/>
-    <script type="text/javascript">
+    <script>
       // me("-") returns the previous sibling element.
       me("-").addEventListener('click', function() {
         let name = this.getAttribute('data-name');
@@ -492,9 +492,9 @@ After building and running the executable, running `curl http://localhost:8080/`
 ```html title="Output"
 <html>
 	<body>
-		<script type="text/javascript">function __templ_printToConsole_5a85(content){console.log(content)}</script>
-		<script type="text/javascript">__templ_printToConsole_5a85("2023-11-11 01:01:40.983381358 +0000 UTC")</script>
-		<script type="text/javascript">__templ_printToConsole_5a85("Again: 2023-11-11 01:01:40.983381358 +0000 UTC")</script>
+		<script>function __templ_printToConsole_5a85(content){console.log(content)}</script>
+		<script>__templ_printToConsole_5a85("2023-11-11 01:01:40.983381358 +0000 UTC")</script>
+		<script>__templ_printToConsole_5a85("Again: 2023-11-11 01:01:40.983381358 +0000 UTC")</script>
 	</body>
 </html>
 ```

--- a/docs/docs/03-syntax-and-usage/17-using-react-with-templ.md
+++ b/docs/docs/03-syntax-and-usage/17-using-react-with-templ.md
@@ -188,7 +188,7 @@ import "fmt"
 
 templ Hello(name string) {
 	<div data-name={ name }>
-		<script type="text/javascript">
+		<script>
 			bundle.renderHello(document.currentScript.closest('div'));
 		</script>
 	</div>
@@ -243,19 +243,19 @@ The HTML that's rendered is:
     <script src="static/index.js"></script>
 
     <div data-name="Alice">
-      <script type="text/javascript">
+      <script>
         // Place the React component into the parent div.
         bundle.renderHello(document.currentScript.closest('div'));
       </script>
     </div>
     <div data-name="Bob">
-      <script type="text/javascript">
+      <script>
         // Place the React component into the parent div.
 	bundle.renderHello(document.currentScript.closest('div'));
       </script>
     </div>
     <div data-name="Charlie">
-      <script type="text/javascript">
+      <script>
         // Place the React component into the parent div.
 	bundle.renderHello(document.currentScript.closest('div'));
       </script>

--- a/docs/docs/03-syntax-and-usage/18-render-once.md
+++ b/docs/docs/03-syntax-and-usage/18-render-once.md
@@ -19,7 +19,7 @@ var helloHandle = templ.NewOnceHandle()
 
 templ hello(label, name string) {
   @helloHandle.Once() {
-    <script type="text/javascript">
+    <script>
       function hello(name) {
         alert('Hello, ' + name + '!');
       }
@@ -35,7 +35,7 @@ templ page() {
 ```
 
 ```html title="Output"
-<script type="text/javascript">
+<script>
   function hello(name) {
     alert('Hello, ' + name + '!');
   }

--- a/docs/docs/10-security/01-injection-attacks.md
+++ b/docs/docs/10-security/01-injection-attacks.md
@@ -6,7 +6,7 @@ templ is designed to prevent user-provided data from being used to inject vulner
 
 ```html
 templ Example() {
-  <script type="text/javascript">
+  <script>
     function showAlert() {
       alert("hello");
     }

--- a/docs/docs/10-security/02-content-security-policy.md
+++ b/docs/docs/10-security/02-content-security-policy.md
@@ -75,12 +75,12 @@ func main() {
 ```
 
 ```html title="Output"
-<script type="text/javascript" nonce="randomly generated nonce">
+<script nonce="randomly generated nonce">
   function __templ_onLoad_5a85() {
     alert("Hello, world!")
   }
 </script>
-<script type="text/javascript" nonce="randomly generated nonce">
+<script nonce="randomly generated nonce">
   __templ_onLoad_5a85()
 </script>
 ```

--- a/examples/integration-react/components.templ
+++ b/examples/integration-react/components.templ
@@ -2,7 +2,7 @@ package main
 
 templ Hello(name string) {
 	<div data-name={ name }>
-		<script type="text/javascript">
+		<script>
 			// Place the React component into the parent div.
 			bundle.renderHello(document.currentScript.closest('div'));
 		</script>

--- a/examples/integration-react/components_templ.go
+++ b/examples/integration-react/components_templ.go
@@ -41,7 +41,7 @@ func Hello(name string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><script type=\"text/javascript\">\n\t\t\t// Place the React component into the parent div.\n\t\t\tbundle.renderHello(document.currentScript.closest('div'));\n\t\t</script></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><script>\n\t\t\t// Place the React component into the parent div.\n\t\t\tbundle.renderHello(document.currentScript.closest('div'));\n\t\t</script></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -973,7 +973,7 @@ func (g *generator) writeElement(indentLevel int, n parser.Element) (err error) 
 		if err = g.writeElementCSS(indentLevel, attrs); err != nil {
 			return err
 		}
-		// <script type="text/javascript"></script>
+		// <script></script>
 		if err = g.writeElementScript(indentLevel, attrs); err != nil {
 			return err
 		}
@@ -1356,7 +1356,7 @@ func (g *generator) writeRawElement(indentLevel int, n parser.RawElement) (err e
 			return err
 		}
 	} else {
-		// <script type="text/javascript"></script>
+		// <script></script>
 		if err = g.writeElementScript(indentLevel, n.Attributes); err != nil {
 			return err
 		}

--- a/generator/test-js-unsafe-usage/expected.html
+++ b/generator/test-js-unsafe-usage/expected.html
@@ -1,6 +1,6 @@
 <button onClick="anythingILike('blah')">
  Click me
 </button>
-<script type="text/javascript">
+<script>
  // Arbitrary JS code
 </script>

--- a/generator/test-js-usage/expected.html
+++ b/generator/test-js-usage/expected.html
@@ -1,7 +1,7 @@
 <button onclick="alert(&#34;Hello, World!&#34;)">
  Click me
 </button>
-<script type="text/javascript">
+<script>
  function customAlert(msg, date) {
 				alert(msg + " " + date);
 			}
@@ -12,7 +12,7 @@
 <button onclick="customAlert(&#34;Hello, custom alert 2: &#34;,&#34;2020-01-01T00:00:00Z&#34;)">
  Click me
 </button>
-<script type="text/javascript">
+<script>
  customAlert("Runs on page load","2020-01-01T00:00:00Z")
 </script>
 <script>

--- a/generator/test-js-usage/template.templ
+++ b/generator/test-js-usage/template.templ
@@ -7,7 +7,7 @@ var onceHandle = templ.NewOnceHandle()
 templ TestComponent() {
 	<button onClick={ templ.JSFuncCall("alert", "Hello, World!") }>Click me</button>
 	@onceHandle.Once() {
-		<script type="text/javascript">
+		<script>
 			function customAlert(msg, date) {
 				alert(msg + " " + date);
 			}

--- a/generator/test-js-usage/template_templ.go
+++ b/generator/test-js-usage/template_templ.go
@@ -61,7 +61,7 @@ func TestComponent() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<script type=\"text/javascript\">\n\t\t\tfunction customAlert(msg, date) {\n\t\t\t\talert(msg + \" \" + date);\n\t\t\t}\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<script>\n\t\t\tfunction customAlert(msg, date) {\n\t\t\t\talert(msg + \" \" + date);\n\t\t\t}\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/generator/test-once/expected.html
+++ b/generator/test-once/expected.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
 			function hello(name) {
 				alert('Hello, ' + name + '!');
 			}

--- a/generator/test-once/template.templ
+++ b/generator/test-once/template.templ
@@ -4,7 +4,7 @@ var helloHandle = templ.NewOnceHandle()
 
 templ hello(label, name string) {
 	@helloHandle.Once() {
-		<script type="text/javascript">
+		<script>
 			function hello(name) {
 				alert('Hello, ' + name + '!');
 			}

--- a/generator/test-once/template_templ.go
+++ b/generator/test-once/template_templ.go
@@ -42,7 +42,7 @@ func hello(label, name string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<script type=\"text/javascript\">\n\t\t\tfunction hello(name) {\n\t\t\t\talert('Hello, ' + name + '!');\n\t\t\t}\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<script>\n\t\t\tfunction hello(name) {\n\t\t\t\talert('Hello, ' + name + '!');\n\t\t\t}\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/generator/test-only-scripts/expected.html
+++ b/generator/test-only-scripts/expected.html
@@ -1,7 +1,7 @@
-<script type="text/javascript">
+<script>
   function __templ_withParameters_1056(a, b, c){console.log(a, b, c);
 }
 </script>
-<script type="text/javascript">
+<script>
   __templ_withParameters_1056("hello","world",42069)
 </script>

--- a/generator/test-raw-elements/expected.html
+++ b/generator/test-raw-elements/expected.html
@@ -7,7 +7,7 @@
           border: 1px solid black;
         }
     </style>
-		<script type="text/javascript">
+		<script>
         $("div").marquee();
         function test() {
               window.open("https://example.com")

--- a/generator/test-raw-elements/template.templ
+++ b/generator/test-raw-elements/template.templ
@@ -10,7 +10,7 @@ templ Example() {
           border: 1px solid black;
         }
       </style>
-			<script type="text/javascript">
+			<script>
         $("div").marquee();
         function test() {
               window.open("https://example.com")

--- a/generator/test-raw-elements/template_templ.go
+++ b/generator/test-raw-elements/template_templ.go
@@ -28,7 +28,7 @@ func Example() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<html><head></head><body><style><!-- Some stuff --></style><style>\n        .customClass {\n          border: 1px solid black;\n        }\n      </style><script type=\"text/javascript\">\n        $(\"div\").marquee();\n        function test() {\n              window.open(\"https://example.com\")\n        }\n      </script><h1>Hello</h1>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<html><head></head><body><style><!-- Some stuff --></style><style>\n        .customClass {\n          border: 1px solid black;\n        }\n      </style><script>\n        $(\"div\").marquee();\n        function test() {\n              window.open(\"https://example.com\")\n        }\n      </script><h1>Hello</h1>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/generator/test-script-inline/expected.html
+++ b/generator/test-script-inline/expected.html
@@ -1,20 +1,20 @@
-<script type="text/javascript">
+<script>
 	function __templ_withoutParameters_6bbf(){alert("hello");
 }
 </script>
-<script type="text/javascript">
+<script>
   __templ_withoutParameters_6bbf()
 </script>
-<script type="text/javascript">
+<script>
   function __templ_withParameters_1056(a, b, c){console.log(a, b, c);
 }
 </script>
-<script type="text/javascript">
+<script>
   __templ_withParameters_1056("injected","test",123)
 </script>
-<script type="text/javascript">
+<script>
   __templ_withoutParameters_6bbf()
 </script>
-<script type="text/javascript">
+<script>
   __templ_withParameters_1056("injected","test",123)
 </script>

--- a/generator/test-script-usage-nonce/expected.html
+++ b/generator/test-script-usage-nonce/expected.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" nonce="nonce1">
+<script nonce="nonce1">
 	function __templ_withParameters_1056(a, b, c){console.log(a, b, c);
 }function __templ_withoutParameters_6bbf(){alert("hello");
 }
@@ -7,12 +7,12 @@
 <button onClick="__templ_withParameters_1056(&#34;test&#34;,&#34;B&#34;,123)" onMouseover="__templ_withoutParameters_6bbf()" type="button">B</button>
 <button onMouseover="console.log(&#39;mouseover&#39;)" type="button">Button C</button>
 <button hx-on::click="alert('clicked inline')" type="button">Button D</button>
-<script type="text/javascript" nonce="nonce1">
+<script nonce="nonce1">
   function __templ_onClick_657d(){alert("clicked");
 }
 </script>
 <button hx-on::click="__templ_onClick_657d()" type="button">Button E</button>
-<script type="text/javascript" nonce="nonce1">
+<script nonce="nonce1">
   function __templ_conditionalScript_de41(){alert("conditional");
 }
 </script>

--- a/generator/test-script-usage/expected.html
+++ b/generator/test-script-usage/expected.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
 	function __templ_withParameters_1056(a, b, c){console.log(a, b, c);
 }function __templ_withoutParameters_6bbf(){alert("hello");
 }
@@ -7,22 +7,22 @@
 <button onClick="__templ_withParameters_1056(&#34;test&#34;,&#34;B&#34;,123)" onMouseover="__templ_withoutParameters_6bbf()" type="button">B</button>
 <button onMouseover="console.log(&#39;mouseover&#39;)" type="button">Button C</button>
 <button hx-on::click="alert('clicked inline')" type="button">Button D</button>
-<script type="text/javascript">
+<script>
   function __templ_onClick_657d(){alert("clicked");
 }
 </script>
 <button hx-on::click="__templ_onClick_657d()" type="button">Button E</button>
-<script type="text/javascript">
+<script>
   function __templ_whenButtonIsClicked_253e(event){console.log(event.target)
 }
 </script>
 <button onclick="__templ_whenButtonIsClicked_253e(event)">Button F</button>
-<script type="text/javascript">
+<script>
   function __templ_conditionalScript_de41(){alert("conditional");
 }
 </script>
 <input type="button" value="Click me" onclick="__templ_conditionalScript_de41()" />
-<script type="text/javascript">
+<script>
   function __templ_alertTest_eadf(){alert('testing');
 }
 </script>

--- a/js_test.go
+++ b/js_test.go
@@ -68,7 +68,7 @@ func TestJSFuncCall(t *testing.T) {
 				Call:       "doSomething()",
 				CallInline: "doSomething()",
 			},
-			expectedComponentOutput: `<script type="text/javascript">doSomething()</script>`,
+			expectedComponentOutput: `<script>doSomething()</script>`,
 		},
 		{
 			name:         "single argument is supported",
@@ -80,7 +80,7 @@ func TestJSFuncCall(t *testing.T) {
 				Call:       "alert(&#34;hello&#34;)",
 				CallInline: `alert("hello")`,
 			},
-			expectedComponentOutput: `<script type="text/javascript">alert("hello")</script>`,
+			expectedComponentOutput: `<script>alert("hello")</script>`,
 		},
 		{
 			name:         "multiple arguments are supported",
@@ -92,7 +92,7 @@ func TestJSFuncCall(t *testing.T) {
 				Call:       "console.log(&#34;hello&#34;,&#34;world&#34;)",
 				CallInline: `console.log("hello","world")`,
 			},
-			expectedComponentOutput: `<script type="text/javascript">console.log("hello","world")</script>`,
+			expectedComponentOutput: `<script>console.log("hello","world")</script>`,
 		},
 		{
 			name:         "attribute injection fails",
@@ -104,7 +104,7 @@ func TestJSFuncCall(t *testing.T) {
 				Call:       "__templ_invalid_js_function_name()",
 				CallInline: "__templ_invalid_js_function_name()",
 			},
-			expectedComponentOutput: `<script type="text/javascript">__templ_invalid_js_function_name()</script>`,
+			expectedComponentOutput: `<script>__templ_invalid_js_function_name()</script>`,
 		},
 		{
 			name:         "closing the script and injecting HTML fails",
@@ -116,7 +116,7 @@ func TestJSFuncCall(t *testing.T) {
 				Call:       "__templ_invalid_js_function_name()",
 				CallInline: "__templ_invalid_js_function_name()",
 			},
-			expectedComponentOutput: `<script type="text/javascript">__templ_invalid_js_function_name()</script>`,
+			expectedComponentOutput: `<script>__templ_invalid_js_function_name()</script>`,
 		},
 	}
 	for _, tt := range tests {

--- a/scripttemplate.go
+++ b/scripttemplate.go
@@ -49,7 +49,7 @@ func writeScriptHeader(ctx context.Context, w io.Writer) (err error) {
 	if nonce := GetNonce(ctx); nonce != "" {
 		nonceAttr = " nonce=\"" + EscapeString(nonce) + "\""
 	}
-	_, err = fmt.Fprintf(w, `<script type="text/javascript"%s>`, nonceAttr)
+	_, err = fmt.Fprintf(w, `<script%s>`, nonceAttr)
 	return err
 }
 

--- a/scripttemplate_test.go
+++ b/scripttemplate_test.go
@@ -28,7 +28,7 @@ func TestRenderScriptItems(t *testing.T) {
 			name:     "if none are ignored, everything is rendered",
 			toIgnore: nil,
 			toRender: []templ.ComponentScript{s1, s2},
-			expected: `<script type="text/javascript">` + s1.Function + s2.Function + `</script>`,
+			expected: `<script>` + s1.Function + s2.Function + `</script>`,
 		},
 		{
 			name: "if something outside the expected is ignored, if has no effect",
@@ -39,13 +39,13 @@ func TestRenderScriptItems(t *testing.T) {
 				},
 			},
 			toRender: []templ.ComponentScript{s1, s2},
-			expected: `<script type="text/javascript">` + s1.Function + s2.Function + `</script>`,
+			expected: `<script>` + s1.Function + s2.Function + `</script>`,
 		},
 		{
 			name:     "if one is ignored, it's not rendered",
 			toIgnore: []templ.ComponentScript{s1},
 			toRender: []templ.ComponentScript{s1, s2},
-			expected: `<script type="text/javascript">` + s2.Function + `</script>`,
+			expected: `<script>` + s2.Function + `</script>`,
 		},
 		{
 			name: "if all are ignored, not even style tags are rendered",


### PR DESCRIPTION
[From the MDN docs about the script element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attribute_is_not_set_default_an_empty_string_or_a_javascript_mime_type):

> Attribute is not set (default), an empty string, or a JavaScript MIME type
> 
> Indicates that the script is a "classic script", containing JavaScript code. Authors are encouraged to omit the attribute if the script refers to JavaScript code rather than specify a MIME type. JavaScript MIME types are listed in the IANA media types specification.

I think it'd be good to reflect the best practices for `<script>` tag usage in templ docs.

Thank you for this library, and keep up the great work!