### PR TITLE
docs: go tool installation and info panel

### DIFF
--- a/docs/docs/02-quick-start/01-installation.md
+++ b/docs/docs/02-quick-start/01-installation.md
@@ -2,12 +2,14 @@
 
 ## go install
 
-With Go 1.23 or greater installed, run:
+With Go 1.24 or greater installed, run:
 
 ```bash
-go install github.com/a-h/templ/cmd/templ@latest
+go get -tool github.com/a-h/templ/cmd/templ@latest
 ```
-
+:::info 
+Since Go 1.24 the [tool directive](https://tip.golang.org/doc/modules/managing-dependencies#tools) has been added. 
+:::
 ## GitHub binaries
 
 Download the latest release from https://github.com/a-h/templ/releases/latest

--- a/docs/docs/02-quick-start/01-installation.md
+++ b/docs/docs/02-quick-start/01-installation.md
@@ -5,11 +5,18 @@
 With Go 1.24 or greater installed, run:
 
 ```bash
+go install github.com/a-h/templ/cmd/templ@latest
+```
+
+To install templ locally in your project, run:
+
+```bash
 go get -tool github.com/a-h/templ/cmd/templ@latest
 ```
 :::info 
 Since Go 1.24 the [tool directive](https://tip.golang.org/doc/modules/managing-dependencies#tools) has been added. 
 :::
+
 ## GitHub binaries
 
 Download the latest release from https://github.com/a-h/templ/releases/latest

--- a/docs/docs/02-quick-start/01-installation.md
+++ b/docs/docs/02-quick-start/01-installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## go install
+## go install (global)
 
 With Go 1.24 or greater installed, run:
 
@@ -8,13 +8,20 @@ With Go 1.24 or greater installed, run:
 go install github.com/a-h/templ/cmd/templ@latest
 ```
 
+This installs templ into your path.
+
+## go install (as tool)
+
 To install templ locally in your project, run:
 
 ```bash
 go get -tool github.com/a-h/templ/cmd/templ@latest
 ```
+
 :::info 
-Since Go 1.24 the [tool directive](https://tip.golang.org/doc/modules/managing-dependencies#tools) has been added. 
+This uses the [tool directive](https://tip.golang.org/doc/modules/managing-dependencies#tools) feature of Go added in v1.24. 
+
+To run templ once installed, use `go tool templ` instead of `templ`.
 :::
 
 ## GitHub binaries


### PR DESCRIPTION
Update templ installation docs to using the new tool directive in Go 1.24 with an info panel linking to the tool directive docs as described here https://github.com/a-h/templ/issues/1067