### PR TITLE
docs: improve vim documentation

### DIFF
--- a/docs/docs/09-developer-tools/02-ide-support.md
+++ b/docs/docs/09-developer-tools/02-ide-support.md
@@ -365,8 +365,6 @@ function! s:on_lsp_buffer_enabled() abort
   nmap <buffer> [g <plug>(lsp-previous-diagnostic)
   nmap <buffer> ]g <plug>(lsp-next-diagnostic)
   nmap <buffer> K <plug>(lsp-hover)
-  nnoremap <buffer> <expr><c-f> lsp#scroll(+4)
-  nnoremap <buffer> <expr><c-d> lsp#scroll(-4)
 
   let g:lsp_format_sync_timeout = 1000
   autocmd! BufWritePre *.templ call execute('LspDocumentFormatSync')

--- a/docs/docs/09-developer-tools/02-ide-support.md
+++ b/docs/docs/09-developer-tools/02-ide-support.md
@@ -330,12 +330,82 @@ require'nvim-treesitter.configs'.setup {
 
 ## Vim
 
-Currently support for vim is limited. Configure formatting with the following VimScript:
+This requires Vim version 8 or later. Install LSP and autocomplete plugins, using
+[vim-plug](https://github.com/junegunn/vim-plug) or other plugin manager.
+
+_Note_: this example is for [vim-lsp](https://github.com/prabirshrestha/vim-lsp). Other LSP plugins can be also
+be used, but they need to be configured differently.
 
 ```vim
-set autoread
-autocmd BufWritePost *.templ silent! execute "!PATH=\"$PATH:$(go env GOPATH)/bin\" templ fmt <afile> >/dev/null 2>&1" | redraw!
+Plug 'prabirshrestha/vim-lsp'
+Plug 'prabirshrestha/asyncomplete.vim'
+Plug 'prabirshrestha/asyncomplete-lsp.vim'
 ```
+
+Add configuration:
+
+```vim
+" Register LSP server for Templ.
+au User lsp_setup call lsp#register_server({
+        \ 'name': 'templ',
+        \ 'cmd': [$GOPATH . '/bin/templ', 'lsp'],
+        \ 'allowlist': ['templ'],
+        \ })
+
+function! s:on_lsp_buffer_enabled() abort
+  setlocal signcolumn=yes
+  if exists('+tagfunc') | setlocal tagfunc=lsp#tagfunc | endif
+  nmap <buffer> gd <plug>(lsp-definition)
+  nmap <buffer> gs <plug>(lsp-document-symbol-search)
+  nmap <buffer> gS <plug>(lsp-workspace-symbol-search)
+  nmap <buffer> gr <plug>(lsp-references)
+  nmap <buffer> gi <plug>(lsp-implementation)
+  nmap <buffer> gt <plug>(lsp-type-definition)
+  nmap <buffer> <leader>rn <plug>(lsp-rename)
+  nmap <buffer> [g <plug>(lsp-previous-diagnostic)
+  nmap <buffer> ]g <plug>(lsp-next-diagnostic)
+  nmap <buffer> K <plug>(lsp-hover)
+  nnoremap <buffer> <expr><c-f> lsp#scroll(+4)
+  nnoremap <buffer> <expr><c-d> lsp#scroll(-4)
+
+  let g:lsp_format_sync_timeout = 1000
+  autocmd! BufWritePre *.templ call execute('LspDocumentFormatSync')
+endfunction
+
+augroup lsp_install
+    au!
+    " call s:on_lsp_buffer_enabled only for languages that has the server registered.
+    autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
+augroup END
+```
+
+See [vim-lsp](https://github.com/prabirshrestha/vim-lsp) for additional configuration options.
+
+Configure autocomplete, for example:
+
+```vim
+inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+inoremap <expr> <cr>    pumvisible() ? asyncomplete#close_popup() : "\<cr>"
+```
+
+See [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim) for more options.
+
+If you're also using [deoplete](https://github.com/Shougo/deoplete.nvim), you may need to disable it for templ files to
+avoid conflict with `asyncomplete`:
+
+```vim
+autocmd FileType templ call deoplete#custom#buffer_option('auto_complete', v:false)
+```
+
+_Optional_: If you'd like indentation to better match Go outside of `templ` blocks, install:
+
+```
+Plug 'iefserge/templ.vim'
+```
+
+* This plugin also adds [tcomment_vim](https://github.com/tomtom/tcomment_vim) support.
+* This is a fork of [joerdav/templ.vim](https://github.com/Joe-Davidson1802/templ.vim).
 
 ## Helix
 


### PR DESCRIPTION
Update Vim documentation and add LSP plugin config example using `vim-lsp`.
It supports auto-formatting on save using LSP as well.

Also I didn't like how indentation worked in templ files, so I forked [joerdav/templ.vim](https://github.com/Joe-Davidson1802/templ.vim) and made it work more like Go files, but with some additions for opening/closing html tags. I added optional section about it, but can remove if you don't like that.



