### PR TITLE
Document templ.EscapeString a little bit more

### DIFF
--- a/docs/docs/03-syntax-and-usage/04-expressions.md
+++ b/docs/docs/03-syntax-and-usage/04-expressions.md
@@ -101,3 +101,5 @@ templ component() {
 ```html title="Output"
 <div>&lt;/div&gt;&lt;script&gt;alert(&#39;hello!&#39;)&lt;/script&gt;&lt;div&gt;</div>
 ```
+
+Manual escaping can be done with the `templ.EscapeString` function, but then you will need to use `@templ.Raw` to avoid double-escaping. See [Rendering raw HTML](/syntax-and-usage/rendering-raw-html) for details.

--- a/docs/docs/03-syntax-and-usage/16-rendering-raw-html.md
+++ b/docs/docs/03-syntax-and-usage/16-rendering-raw-html.md
@@ -3,7 +3,7 @@
 To render HTML that has come from a trusted source, bypassing all HTML escaping and security mechanisms that templ includes, use the `templ.Raw` function.
 
 :::info
-Only include HTML that comes from a trusted source.
+Only include HTML that comes from a trusted source. Use the `templ.EscapeString` function to escape content that comes from untrusted sources.
 :::
 
 :::warning


### PR DESCRIPTION
Right now, that function's name is hidden in a single place in the documentation, and searching for "escape" or "escaping" doesn't make it easy to find.

By mentioning it in some relevant places, we make it easier for devs to find it.