### PR TITLE
Conditionalize language server preload

### DIFF
--- a/cmd/templ/lspcmd/main.go
+++ b/cmd/templ/lspcmd/main.go
@@ -26,6 +26,8 @@ type Arguments struct {
 	PPROF bool
 	// HTTPDebug sets the HTTP endpoint to listen on. Leave empty for no web debug.
 	HTTPDebug string
+	// NoPreload disables preloading of templ files on server startup (useful for large monorepos)
+	NoPreload bool
 }
 
 func Run(stdin io.Reader, stdout, stderr io.Writer, args Arguments) (err error) {
@@ -95,7 +97,7 @@ func run(ctx context.Context, log *slog.Logger, templStream jsonrpc2.Stream, arg
 
 	log.Info("creating proxy")
 	// Create the proxy to sit between.
-	serverProxy := proxy.NewServer(log, goplsServer, cache, diagnosticCache)
+	serverProxy := proxy.NewServer(log, goplsServer, cache, diagnosticCache, args.NoPreload)
 
 	// Create templ server.
 	log.Info("creating templ server")

--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -240,7 +240,7 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 	}
 
 	if !p.NoPreload {
-		p.preload(params.WorkspaceFolders)
+		p.preload(ctx, params.WorkspaceFolders)
 	}
 
 	result.ServerInfo.Name = "templ-lsp"
@@ -249,7 +249,7 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 	return result, err
 }
 
-func (p *Server) preload(workspaceFolders []lsp.WorkspaceFolder) {
+func (p *Server) preload(ctx context.Context, workspaceFolders []lsp.WorkspaceFolder) {
 	for _, c := range workspaceFolders {
 		path := strings.TrimPrefix(c.URI, "file://")
 		werr := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {

--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -40,10 +40,11 @@ type Server struct {
 	DiagnosticCache *DiagnosticCache
 	TemplSource     *DocumentContents
 	GoSource        map[string]string
+	NoPreload       bool
 	preLoadURIs     []*lsp.DidOpenTextDocumentParams
 }
 
-func NewServer(log *slog.Logger, target lsp.Server, cache *SourceMapCache, diagnosticCache *DiagnosticCache) (s *Server) {
+func NewServer(log *slog.Logger, target lsp.Server, cache *SourceMapCache, diagnosticCache *DiagnosticCache, noPreload bool) (s *Server) {
 	return &Server{
 		Log:             log,
 		Target:          target,
@@ -51,6 +52,7 @@ func NewServer(log *slog.Logger, target lsp.Server, cache *SourceMapCache, diagn
 		DiagnosticCache: diagnosticCache,
 		TemplSource:     newDocumentContents(log),
 		GoSource:        make(map[string]string),
+		NoPreload:       noPreload,
 	}
 }
 
@@ -237,58 +239,60 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 		Save:              &lsp.SaveOptions{IncludeText: true},
 	}
 
-	for _, c := range params.WorkspaceFolders {
-		path := strings.TrimPrefix(c.URI, "file://")
-		werr := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			p.Log.Info("found file", slog.String("path", path))
-			uri := uri.URI("file://" + path)
-			isTemplFile, goURI := convertTemplToGoURI(uri)
+	if !p.NoPreload {
+		for _, c := range params.WorkspaceFolders {
+			path := strings.TrimPrefix(c.URI, "file://")
+			werr := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				p.Log.Info("found file", slog.String("path", path))
+				uri := uri.URI("file://" + path)
+				isTemplFile, goURI := convertTemplToGoURI(uri)
 
-			if !isTemplFile {
+				if !isTemplFile {
+					return nil
+				}
+
+				b, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				p.TemplSource.Set(string(uri), NewDocument(p.Log, string(b)))
+				// Parse the template.
+				template, ok, err := p.parseTemplate(ctx, uri, string(b))
+				if err != nil {
+					p.Log.Error("parseTemplate failure", slog.Any("error", err))
+				}
+				if !ok {
+					p.Log.Info("parsing template did not succeed", slog.String("uri", string(uri)))
+					return nil
+				}
+				w := new(strings.Builder)
+				generatorOutput, err := generator.Generate(template, w)
+				if err != nil {
+					return fmt.Errorf("generate failure: %w", err)
+				}
+				p.Log.Info("setting source map cache contents", slog.String("uri", string(uri)))
+				p.SourceMapCache.Set(string(uri), generatorOutput.SourceMap)
+				// Set the Go contents.
+				p.GoSource[string(uri)] = w.String()
+
+				didOpenParams := &lsp.DidOpenTextDocumentParams{
+					TextDocument: lsp.TextDocumentItem{
+						URI:        goURI,
+						Text:       w.String(),
+						Version:    1,
+						LanguageID: "go",
+					},
+				}
+
+				p.preLoadURIs = append(p.preLoadURIs, didOpenParams)
 				return nil
+			})
+			if werr != nil {
+				p.Log.Error("walk error", slog.Any("error", werr))
 			}
-
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			p.TemplSource.Set(string(uri), NewDocument(p.Log, string(b)))
-			// Parse the template.
-			template, ok, err := p.parseTemplate(ctx, uri, string(b))
-			if err != nil {
-				p.Log.Error("parseTemplate failure", slog.Any("error", err))
-			}
-			if !ok {
-				p.Log.Info("parsing template did not succeed", slog.String("uri", string(uri)))
-				return nil
-			}
-			w := new(strings.Builder)
-			generatorOutput, err := generator.Generate(template, w)
-			if err != nil {
-				return fmt.Errorf("generate failure: %w", err)
-			}
-			p.Log.Info("setting source map cache contents", slog.String("uri", string(uri)))
-			p.SourceMapCache.Set(string(uri), generatorOutput.SourceMap)
-			// Set the Go contents.
-			p.GoSource[string(uri)] = w.String()
-
-			didOpenParams := &lsp.DidOpenTextDocumentParams{
-				TextDocument: lsp.TextDocumentItem{
-					URI:        goURI,
-					Text:       w.String(),
-					Version:    1,
-					LanguageID: "go",
-				},
-			}
-
-			p.preLoadURIs = append(p.preLoadURIs, didOpenParams)
-			return nil
-		})
-		if werr != nil {
-			p.Log.Error("walk error", slog.Any("error", werr))
 		}
 	}
 

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -359,7 +359,7 @@ Args:
     Enable pprof web server (default address is localhost:9999)
   -http string
     Enable http debug server by setting a listen address (e.g. localhost:7474)
-  -noPreload
+  -no-preload
     Disable preloading of templ files on server startup (useful for large monorepos)
 `
 
@@ -371,7 +371,7 @@ func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 	helpFlag := cmd.Bool("help", false, "")
 	pprofFlag := cmd.Bool("pprof", false, "")
 	httpDebugFlag := cmd.String("http", "", "")
-	noPreloadFlag := cmd.Bool("noPreload", false, "")
+	noPreloadFlag := cmd.Bool("no-preload", false, "")
 	err := cmd.Parse(args)
 	if err != nil {
 		fmt.Fprint(stderr, lspUsageText)

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -172,7 +172,7 @@ Args:
   -w
     Number of workers to use when generating code. (default runtime.NumCPUs)
   -lazy
-    Only generate .go files if the source .templ file is newer.	
+    Only generate .go files if the source .templ file is newer. 
   -pprof
     Port to run the pprof server on.
   -keep-orphaned-files
@@ -359,6 +359,8 @@ Args:
     Enable pprof web server (default address is localhost:9999)
   -http string
     Enable http debug server by setting a listen address (e.g. localhost:7474)
+  -noPreload
+    Disable preloading of templ files on server startup (useful for large monorepos)
 `
 
 func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int) {
@@ -369,6 +371,7 @@ func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 	helpFlag := cmd.Bool("help", false, "")
 	pprofFlag := cmd.Bool("pprof", false, "")
 	httpDebugFlag := cmd.String("http", "", "")
+	noPreloadFlag := cmd.Bool("noPreload", false, "")
 	err := cmd.Parse(args)
 	if err != nil {
 		fmt.Fprint(stderr, lspUsageText)
@@ -385,6 +388,7 @@ func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 		GoplsRPCTrace: *goplsRPCTrace,
 		PPROF:         *pprofFlag,
 		HTTPDebug:     *httpDebugFlag,
+		NoPreload:     *noPreloadFlag,
 	})
 	if err != nil {
 		fmt.Fprintln(stderr, err.Error())


### PR DESCRIPTION
Allow disabling of language server preload through a command line flag to fix performance issues in large monorepos.

Closes #1117.