### PR TITLE
feat: Add support for starting gopls in shared daemon mode

### DIFF
--- a/cmd/templ/lspcmd/main.go
+++ b/cmd/templ/lspcmd/main.go
@@ -22,6 +22,7 @@ type Arguments struct {
 	Log           string
 	GoplsLog      string
 	GoplsRPCTrace bool
+	GoplsRemote   string
 	// PPROF sets whether to start a profiling server on localhost:9999
 	PPROF bool
 	// HTTPDebug sets the HTTP endpoint to listen on. Leave empty for no web debug.
@@ -81,6 +82,7 @@ func run(ctx context.Context, log *slog.Logger, templStream jsonrpc2.Stream, arg
 	rwc, err := pls.NewGopls(ctx, log, pls.Options{
 		Log:      args.GoplsLog,
 		RPCTrace: args.GoplsRPCTrace,
+		Remote:   args.GoplsRemote,
 	})
 	if err != nil {
 		log.Error("failed to start gopls", slog.Any("error", err))

--- a/cmd/templ/lspcmd/pls/main.go
+++ b/cmd/templ/lspcmd/pls/main.go
@@ -16,6 +16,7 @@ import (
 type Options struct {
 	Log      string
 	RPCTrace bool
+	Remote   string
 }
 
 // AsArguments converts the options into command line arguments for gopls.
@@ -26,6 +27,9 @@ func (opts Options) AsArguments() []string {
 	}
 	if opts.RPCTrace {
 		args = append(args, "-rpc.trace")
+	}
+	if opts.Remote != "" {
+		args = append(args, "-remote", opts.Remote)
 	}
 	return args
 }

--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -353,6 +353,8 @@ Args:
     The file to log gopls output, or leave empty to disable logging.
   -goplsRPCTrace
     Set gopls to log input and output messages.
+  -gopls-remote
+    Specify remote gopls instance to connect to.
   -help
     Print help and exit.
   -pprof
@@ -368,6 +370,7 @@ func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 	logFlag := cmd.String("log", "", "")
 	goplsLog := cmd.String("goplsLog", "", "")
 	goplsRPCTrace := cmd.Bool("goplsRPCTrace", false, "")
+	goplsRemote := cmd.String("gopls-remote", "", "")
 	helpFlag := cmd.Bool("help", false, "")
 	pprofFlag := cmd.Bool("pprof", false, "")
 	httpDebugFlag := cmd.String("http", "", "")
@@ -386,6 +389,7 @@ func lspCmd(stdin io.Reader, stdout, stderr io.Writer, args []string) (code int)
 		Log:           *logFlag,
 		GoplsLog:      *goplsLog,
 		GoplsRPCTrace: *goplsRPCTrace,
+		GoplsRemote:   *goplsRemote,
 		PPROF:         *pprofFlag,
 		HTTPDebug:     *httpDebugFlag,
 		NoPreload:     *noPreloadFlag,


### PR DESCRIPTION
Templ LSP currently creates its own instance of Gopls. Gopls supports a shared daemon mode via the `-remote` flag, enabling multiple clients to connect to a single, long-lived Gopls instance.

Add a `-gopls-remote` flag to the `lsp` command to create or connect to a shared Gopls instance, improving efficiency and reducing overhead.

Closes #1141.