### PR TITLE
chore: constrain CI/CD workflow permissions to read only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/a-h/templ/security/code-scanning/10](https://github.com/a-h/templ/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the workflow level to apply minimal permissions to all jobs. Since the workflow primarily involves CI tasks like building, testing, and linting, it likely only requires `contents: read`. If any job requires additional permissions, we can override the workflow-level permissions by adding a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
