### PR TITLE
fix: include all watch patterns in consideration for cmd restart

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -57,10 +57,10 @@ type Generate struct {
 }
 
 type GenerationEvent struct {
-	Event       fsnotify.Event
-	Updated     bool
-	GoUpdated   bool
-	TextUpdated bool
+	Event            fsnotify.Event
+	WatchfileUpdated bool
+	GoUpdated        bool
+	TextUpdated      bool
 }
 
 func (cmd Generate) Run(ctx context.Context) (err error) {
@@ -229,15 +229,15 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 				if err != nil {
 					errs <- err
 				}
-				if !(r.GoUpdated || r.TextUpdated) {
+				if !(r.GoUpdated || r.TextUpdated || r.WatchfileUpdated) {
 					cmd.Log.Debug("File not updated", slog.String("file", event.Name))
 					return
 				}
 				e := &GenerationEvent{
-					Event:       event,
-					Updated:     r.Updated,
-					GoUpdated:   r.GoUpdated,
-					TextUpdated: r.TextUpdated,
+					Event:            event,
+					WatchfileUpdated: r.WatchfileUpdated,
+					GoUpdated:        r.GoUpdated,
+					TextUpdated:      r.TextUpdated,
 				}
 				cmd.Log.Debug("File updated", slog.String("file", event.Name))
 				postGeneration <- e
@@ -256,7 +256,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 		defer postGenerationWG.Done()
 		cmd.Log.Debug("Starting post-generation handler")
 		timeout := time.NewTimer(time.Hour * 24 * 365)
-		var goUpdated, textUpdated bool
+		var goUpdated, textUpdated, watchfileUpdated bool
 		var p *proxy.Handler
 		for {
 			select {
@@ -266,8 +266,9 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 					return
 				}
 				goUpdated = goUpdated || ge.GoUpdated
+				watchfileUpdated = watchfileUpdated || ge.WatchfileUpdated
 				textUpdated = textUpdated || ge.TextUpdated
-				if goUpdated || textUpdated {
+				if goUpdated || textUpdated || watchfileUpdated {
 					updates++
 				}
 				// Reset timer.
@@ -276,13 +277,13 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 				}
 				timeout.Reset(time.Millisecond * 100)
 			case <-timeout.C:
-				if !goUpdated && !textUpdated {
+				if !goUpdated && !textUpdated && !watchfileUpdated {
 					// Nothing to process, reset timer and wait again.
 					timeout.Reset(time.Hour * 24 * 365)
 					break
 				}
 				postGenerationEventsWG.Add(1)
-				if cmd.Args.Command != "" && goUpdated {
+				if cmd.Args.Command != "" && (goUpdated || watchfileUpdated) {
 					cmd.Log.Debug("Executing command", slog.String("command", cmd.Args.Command))
 					if cmd.Args.Watch {
 						os.Setenv("TEMPL_DEV_MODE", "true")
@@ -300,7 +301,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 					}
 				}
 				// Send server-sent event.
-				if p != nil && (textUpdated || goUpdated) {
+				if p != nil && (textUpdated || goUpdated || watchfileUpdated) {
 					cmd.Log.Debug("Sending reload event")
 					p.SendSSE("message", "reload")
 				}
@@ -309,6 +310,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 				timeout.Reset(time.Millisecond * 100)
 				textUpdated = false
 				goUpdated = false
+				watchfileUpdated = false
 			}
 		}
 	}()

--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -94,8 +94,8 @@ type FSEventHandler struct {
 }
 
 type GenerateResult struct {
-	// Updated indicates that the file was updated.
-	Updated bool
+	// WatchfileUpdated indicates that a file matching the watch pattern was updated.
+	WatchfileUpdated bool
 	// GoUpdated indicates that Go expressions were updated.
 	GoUpdated bool
 	// TextUpdated indicates that text literals were updated.
@@ -117,7 +117,7 @@ func (h *FSEventHandler) HandleEvent(ctx context.Context, event fsnotify.Event) 
 		if err = os.Remove(event.Name); err != nil {
 			h.Log.Warn("Failed to remove orphaned file", slog.Any("error", err))
 		}
-		return GenerateResult{Updated: true, GoUpdated: true, TextUpdated: false}, nil
+		return GenerateResult{WatchfileUpdated: true, GoUpdated: true, TextUpdated: false}, nil
 	}
 
 	// If the file hasn't been updated since the last time we processed it, ignore it.
@@ -133,7 +133,7 @@ func (h *FSEventHandler) HandleEvent(ctx context.Context, event fsnotify.Event) 
 		if strings.HasSuffix(event.Name, ".go") {
 			result.GoUpdated = true
 		}
-		result.Updated = true
+		result.WatchfileUpdated = true
 		return result, nil
 	}
 
@@ -253,7 +253,7 @@ func (h *FSEventHandler) generate(ctx context.Context, fileName string) (result 
 	// Hash output, and write out the file if the goCodeHash has changed.
 	goCodeHash := sha256.Sum256(formattedGoCode)
 	if h.UpsertHash(targetFileName, goCodeHash) {
-		result.Updated = true
+		result.WatchfileUpdated = true
 		if err = h.writer(targetFileName, formattedGoCode); err != nil {
 			return result, nil, fmt.Errorf("failed to write target file %q: %w", targetFileName, err)
 		}


### PR DESCRIPTION
When `-watch-pattern` is set and a non-go, non-text (`_templ.txt`) file changes that matches the pattern, processing the change is effectively a no-op because templ only restarts the `-cmd` when Go files change.

A use case for this change is when one uses `//go:embed` directives to embed non-Go assets in go binaries. E.g. when changes are made to `app.js` and `-cmd` is set to `go run main.go`, templ must restart the `-cmd` for changes to be seen. 
 
This change causes templ to re-run its "cmd" argument any time files matching its -watch-pattern change.
