### PR TITLE
feat: gracefully shutdown on sigterm in `-watch` mode 

### DIFF
--- a/cmd/templ/main.go
+++ b/cmd/templ/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 
 	"github.com/a-h/templ"
 	"github.com/a-h/templ/cmd/templ/fmtcmd"
@@ -236,7 +237,7 @@ func generateCmd(stdout, stderr io.Writer, args []string) (code int) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-signalChan
 		fmt.Fprintln(stderr, "Stopping...")


### PR DESCRIPTION
To handle graceful shutdown requests, templ needs to handle `SIGTERM` signals from the operating system.

Templ is difficult to use in signal-based systems like `process-compose` because it does not gracefully shutdown, and thus, is unable to gracefully restart when externally signalled to do so. 
