### PR TITLE
Do not block if timer has run out

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -272,9 +272,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 					updates++
 				}
 				// Reset timer.
-				if !timeout.Stop() {
-					<-timeout.C
-				}
+				timeout.Stop()
 				timeout.Reset(time.Millisecond * 100)
 			case <-timeout.C:
 				if !goUpdated && !textUpdated && !watchedFileUpdated {


### PR DESCRIPTION
The go documentation states:

> For a chan-based timer created with NewTimer(d), as of Go 1.23, any receive from t.C after Stop has returned is guaranteed to block rather than receive a stale time value from before the Stop; if the program has not received from t.C already and the timer is running, Stop is guaranteed to return true. Before Go 1.23, the only safe way to use Stop was insert an extra <-t.C if Stop returned false to drain a potential stale value.

https://pkg.go.dev/time#Timer.Stop