### PR TITLE
Refactor filesystem event handler into a separate section

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -63,7 +63,7 @@ type GenerationEvent struct {
 	TextUpdated        bool
 }
 
-func (cmd Generate) Run(ctx context.Context) (err error) {
+func (cmd Generate) Run(ctx context.Context) error {
 	if cmd.Args.NotifyProxy {
 		return proxy.NotifyProxy(cmd.Args.ProxyBind, cmd.Args.ProxyPort)
 	}
@@ -86,6 +86,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 
 	// Use absolute path.
 	if !path.IsAbs(cmd.Args.Path) {
+		var err error
 		cmd.Args.Path, err = filepath.Abs(cmd.Args.Path)
 		if err != nil {
 			return fmt.Errorf("failed to get absolute path: %w", err)


### PR DESCRIPTION
Refactors the generatecmd::Run function into two functions, to reduce complexity. In doing so, I noticed that a few instances of error handling operate by defining a new variable `err` and logging and/or returning it immediately, while another instance assigns the preexisting symbol `err` which represents the return value. Because this logic was very unclear, I renamed the top-level `err` to `proxyError` (since it is only used for the proxy) and removed the named-return value so that any assignment to `err` must be its own contained definition to make for better readability.