### PR TITLE
fix: Handle live import declaration changes in lazy loader

### DIFF
--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -250,7 +250,7 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 				didOpen:  p.didOpen,
 				didClose: p.didClose,
 			},
-			openTemplDocSources: p.TemplSource,
+			openDocSources: p.GoSource,
 		})
 	} else {
 		p.preload(ctx, params.WorkspaceFolders)

--- a/cmd/templ/lspcmd/proxy/templdoclazyloader.go
+++ b/cmd/templ/lspcmd/proxy/templdoclazyloader.go
@@ -3,6 +3,10 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -13,10 +17,12 @@ import (
 
 // templDocLazyLoader is a loader that uses the packages API to lazily load templ documents in the dependency graph.
 type templDocLazyLoader struct {
-	templDocHooks templDocHooks
-	packageLoader packageLoader
-	fileReader    fileReader
-	pkgsRefCount  map[string]int
+	templDocHooks  templDocHooks
+	packageLoader  packageLoader
+	fileReader     fileReader
+	fileParser     fileParser
+	pkgsRefCount   map[string]int
+	openDocHeaders map[string]*goDocHeader
 }
 
 type templDocHooks struct {
@@ -35,6 +41,18 @@ type fileReader interface {
 }
 
 type templFileReader struct{}
+
+type fileParser interface {
+	parseFile(fset *token.FileSet, file string, overlay any, mode parser.Mode) (*ast.File, error)
+}
+
+type templFileParser struct{}
+
+type goDocHeader struct {
+	pkgName   string
+	imports   map[string]struct{}
+	textRange *lsp.Range
+}
 
 func (goPackageLoader) load(file string) (*packages.Package, error) {
 	pkgs, err := packages.Load(
@@ -59,12 +77,40 @@ func (templFileReader) read(file string) ([]byte, error) {
 	return os.ReadFile(file)
 }
 
+func (templFileParser) parseFile(fset *token.FileSet, file string, overlay any, mode parser.Mode) (*ast.File, error) {
+	return parser.ParseFile(fset, file, overlay, mode)
+}
+
+func (g *goDocHeader) equals(other *goDocHeader) bool {
+	if other == nil {
+		return false
+	}
+
+	if g.pkgName != other.pkgName {
+		return false
+	}
+
+	if len(g.imports) != len(other.imports) {
+		return false
+	}
+
+	for imp := range g.imports {
+		if _, ok := other.imports[imp]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 func newTemplDocLazyLoader(templDocHooks templDocHooks) templDocLazyLoader {
 	return templDocLazyLoader{
-		templDocHooks: templDocHooks,
-		packageLoader: goPackageLoader{},
-		fileReader:    templFileReader{},
-		pkgsRefCount:  make(map[string]int),
+		templDocHooks:  templDocHooks,
+		packageLoader:  goPackageLoader{},
+		fileReader:     templFileReader{},
+		fileParser:     templFileParser{},
+		pkgsRefCount:   make(map[string]int),
+		openDocHeaders: make(map[string]*goDocHeader),
 	}
 }
 
@@ -81,7 +127,34 @@ func (l *templDocLazyLoader) load(ctx context.Context, params *lsp.DidOpenTextDo
 		return fmt.Errorf("open topologically %q: %w", pkg.PkgPath, err)
 	}
 
+	l.openDocHeaders[filename] = l.parseHeader(filename, nil)
+
 	return nil
+}
+
+// sync opens newly added dependencies and closes those that are no longer necessary.
+func (l *templDocLazyLoader) sync(_ context.Context, params *lsp.DidChangeTextDocumentParams, overlay any) error {
+	filename := params.TextDocument.URI.Filename()
+	header := l.openDocHeaders[filename]
+
+	didChangeHeader := false
+	for _, change := range params.ContentChanges {
+		if change.Range == nil || change.Range.Start.Line < header.textRange.End.Line {
+			didChangeHeader = true
+			break
+		}
+	}
+
+	if !didChangeHeader {
+		return nil
+	}
+
+	l.openDocHeaders[filename] = l.parseHeader(filename, overlay)
+	if l.openDocHeaders[filename].equals(header) {
+		return nil
+	}
+
+	return fmt.Errorf("not implemented")
 }
 
 // openTopologically opens templ files in dependency-first order (topological sort).
@@ -128,6 +201,47 @@ func (l *templDocLazyLoader) openTopologically(ctx context.Context, pkg *package
 	return nil
 }
 
+// parseHeader parses the header from a templ file using the provided overlay contents when available.
+func (l *templDocLazyLoader) parseHeader(filename string, overlay any) *goDocHeader {
+	fset := token.NewFileSet()
+	file, err := l.fileParser.parseFile(fset, filename, overlay, parser.ImportsOnly)
+	if err != nil {
+		return &goDocHeader{
+			textRange: &lsp.Range{
+				End: lsp.Position{
+					Line: math.MaxUint32,
+				},
+			},
+		}
+	}
+
+	header := &goDocHeader{
+		pkgName: file.Name.Name,
+		imports: make(map[string]struct{}),
+	}
+
+	if len(file.Imports) == 0 {
+		header.textRange = &lsp.Range{
+			End: lsp.Position{
+				Line: uint32(fset.File(file.Pos()).LineCount()) + 1,
+			},
+		}
+		return header
+	}
+
+	for _, imp := range file.Imports {
+		header.imports[imp.Path.Value] = struct{}{}
+	}
+
+	lastImportPos := file.Imports[len(file.Imports)-1].Pos()
+	header.textRange = &lsp.Range{
+		End: lsp.Position{
+			Line: uint32(fset.Position(lastImportPos).Line) + 1,
+		},
+	}
+	return header
+}
+
 // unload unloads all templ documents in the dependency graph topologically (dependents are unloaded before dependencies).
 func (l *templDocLazyLoader) unload(ctx context.Context, params *lsp.DidCloseTextDocumentParams) error {
 	filename := params.TextDocument.URI.Filename()
@@ -140,6 +254,8 @@ func (l *templDocLazyLoader) unload(ctx context.Context, params *lsp.DidCloseTex
 	if err := l.closeTopologically(ctx, pkg, make(map[string]bool)); err != nil {
 		return fmt.Errorf("close topologically %q: %w", pkg.PkgPath, err)
 	}
+
+	delete(l.openDocHeaders, filename)
 
 	return nil
 }

--- a/cmd/templ/lspcmd/proxy/templdoclazyloader_test.go
+++ b/cmd/templ/lspcmd/proxy/templdoclazyloader_test.go
@@ -30,7 +30,7 @@ type mockFileParser struct {
 	source map[string]string
 }
 
-func (m mockPackageLoader) load(file string) (*packages.Package, error) {
+func (m mockPackageLoader) load(_ *packages.Config, file string) (*packages.Package, error) {
 	return m.packages[file], m.err[file]
 }
 

--- a/cmd/templ/lspcmd/proxy/templdoclazyloader_test.go
+++ b/cmd/templ/lspcmd/proxy/templdoclazyloader_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type mockPackageLoader struct {
-	packages map[string][]*packages.Package
+	packages map[string]*packages.Package
 	err      map[string]error
 }
 
@@ -22,7 +22,7 @@ type mockFileReader struct {
 	err  map[string]error
 }
 
-func (m mockPackageLoader) load(file string) ([]*packages.Package, error) {
+func (m mockPackageLoader) load(file string) (*packages.Package, error) {
 	return m.packages[file], m.err[file]
 }
 
@@ -73,18 +73,16 @@ func TestLoad(t *testing.T) {
 					URI: uri.URI("file:///a.templ"),
 				},
 			},
-			wantErrStr: "load packages for file \"/a.templ\": error",
+			wantErrStr: "load package for file \"/a.templ\": error",
 		},
 		{
 			name: "err read file",
 			loader: templDocLazyLoader{
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ"},
-							},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ"},
 						},
 					},
 				},
@@ -112,12 +110,10 @@ func TestLoad(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ"},
-							},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ"},
 						},
 					},
 				},
@@ -146,20 +142,18 @@ func TestLoad(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ", "/a_other.templ"},
-								Imports: map[string]*packages.Package{
-									"b": {
-										PkgPath:    "b",
-										OtherFiles: []string{"/b.templ"},
-										Imports: map[string]*packages.Package{
-											"c": {
-												PkgPath:    "c",
-												OtherFiles: []string{"/c.templ", "/c_other.templ"},
-											},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ", "/a_other.templ"},
+							Imports: map[string]*packages.Package{
+								"b": {
+									PkgPath:    "b",
+									OtherFiles: []string{"/b.templ"},
+									Imports: map[string]*packages.Package{
+										"c": {
+											PkgPath:    "c",
+											OtherFiles: []string{"/c.templ", "/c_other.templ"},
 										},
 									},
 								},
@@ -200,24 +194,22 @@ func TestLoad(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ", "/a_other.templ"},
-								Imports: map[string]*packages.Package{
-									"b": {
-										PkgPath:    "b",
-										OtherFiles: []string{"/b.templ"},
-										Imports: map[string]*packages.Package{
-											"c": {
-												PkgPath:    "c",
-												OtherFiles: []string{"/c.templ", "/c_other.templ"},
-												Imports: map[string]*packages.Package{
-													"a": {
-														PkgPath:    "a",
-														OtherFiles: []string{"/a_loop.templ", "/a_other_loop.templ"},
-													},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ", "/a_other.templ"},
+							Imports: map[string]*packages.Package{
+								"b": {
+									PkgPath:    "b",
+									OtherFiles: []string{"/b.templ"},
+									Imports: map[string]*packages.Package{
+										"c": {
+											PkgPath:    "c",
+											OtherFiles: []string{"/c.templ", "/c_other.templ"},
+											Imports: map[string]*packages.Package{
+												"a": {
+													PkgPath:    "a",
+													OtherFiles: []string{"/a_loop.templ", "/a_other_loop.templ"},
 												},
 											},
 										},
@@ -260,20 +252,18 @@ func TestLoad(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ", "/a_other.templ"},
-								Imports: map[string]*packages.Package{
-									"b": {
-										PkgPath:    "b",
-										OtherFiles: []string{"/b.templ"},
-										Imports: map[string]*packages.Package{
-											"c": {
-												PkgPath:    "c",
-												OtherFiles: []string{"/c.templ", "/c_other.templ"},
-											},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ", "/a_other.templ"},
+							Imports: map[string]*packages.Package{
+								"b": {
+									PkgPath:    "b",
+									OtherFiles: []string{"/b.templ"},
+									Imports: map[string]*packages.Package{
+										"c": {
+											PkgPath:    "c",
+											OtherFiles: []string{"/c.templ", "/c_other.templ"},
 										},
 									},
 								},
@@ -355,7 +345,7 @@ func TestUnload(t *testing.T) {
 					URI: uri.URI("file:///a.templ"),
 				},
 			},
-			wantErrStr: "load packages for file \"/a.templ\": error",
+			wantErrStr: "load package for file \"/a.templ\": error",
 		},
 		{
 			name: "err did close",
@@ -366,12 +356,10 @@ func TestUnload(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ"},
-							},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ"},
 						},
 					},
 				},
@@ -404,20 +392,18 @@ func TestUnload(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ", "/a_other.templ"},
-								Imports: map[string]*packages.Package{
-									"b": {
-										PkgPath:    "b",
-										OtherFiles: []string{"/b.templ"},
-										Imports: map[string]*packages.Package{
-											"c": {
-												PkgPath:    "c",
-												OtherFiles: []string{"/c.templ", "/c_other.templ"},
-											},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ", "/a_other.templ"},
+							Imports: map[string]*packages.Package{
+								"b": {
+									PkgPath:    "b",
+									OtherFiles: []string{"/b.templ"},
+									Imports: map[string]*packages.Package{
+										"c": {
+											PkgPath:    "c",
+											OtherFiles: []string{"/c.templ", "/c_other.templ"},
 										},
 									},
 								},
@@ -458,24 +444,22 @@ func TestUnload(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/a.templ": {
-							{
-								PkgPath:    "a",
-								OtherFiles: []string{"/a.templ", "/a_other.templ"},
-								Imports: map[string]*packages.Package{
-									"b": {
-										PkgPath:    "b",
-										OtherFiles: []string{"/b.templ"},
-										Imports: map[string]*packages.Package{
-											"c": {
-												PkgPath:    "c",
-												OtherFiles: []string{"/c.templ", "/c_other.templ"},
-												Imports: map[string]*packages.Package{
-													"a": {
-														PkgPath:    "a",
-														OtherFiles: []string{"/a_loop.templ", "/a_other_loop.templ"},
-													},
+							PkgPath:    "a",
+							OtherFiles: []string{"/a.templ", "/a_other.templ"},
+							Imports: map[string]*packages.Package{
+								"b": {
+									PkgPath:    "b",
+									OtherFiles: []string{"/b.templ"},
+									Imports: map[string]*packages.Package{
+										"c": {
+											PkgPath:    "c",
+											OtherFiles: []string{"/c.templ", "/c_other.templ"},
+											Imports: map[string]*packages.Package{
+												"a": {
+													PkgPath:    "a",
+													OtherFiles: []string{"/a_loop.templ", "/a_other_loop.templ"},
 												},
 											},
 										},
@@ -518,16 +502,14 @@ func TestUnload(t *testing.T) {
 					},
 				},
 				packageLoader: mockPackageLoader{
-					packages: map[string][]*packages.Package{
+					packages: map[string]*packages.Package{
 						"/b.templ": {
-							{
-								PkgPath:    "b",
-								OtherFiles: []string{"/b.templ"},
-								Imports: map[string]*packages.Package{
-									"c": {
-										PkgPath:    "c",
-										OtherFiles: []string{"/c.templ", "/c_other.templ"},
-									},
+							PkgPath:    "b",
+							OtherFiles: []string{"/b.templ"},
+							Imports: map[string]*packages.Package{
+								"c": {
+									PkgPath:    "c",
+									OtherFiles: []string{"/c.templ", "/c_other.templ"},
 								},
 							},
 						},


### PR DESCRIPTION
Synchronize the lazy loader with changes to the import section of a templ file. When the imports in a file change (e.g. new or removed dependencies), we now correctly:
- Detect additions to the import graph and open new packages and their transitive dependencies if necessary
- Detect removals and close packages that are no longer required

This ensures that the loader maintains a consistent set of open templ files in response to live edits to import declarations, and avoids broken import-related bugs.