### PR TITLE
fix: prevent request failure notification spam for new files

### DIFF
--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -368,6 +368,12 @@ var supportedCodeActions = map[string]bool{}
 func (p *Server) CodeAction(ctx context.Context, params *lsp.CodeActionParams) (result []lsp.CodeAction, err error) {
 	p.Log.Info("client -> server: CodeAction", slog.Any("params", params))
 	defer p.Log.Info("client -> server: CodeAction end")
+
+	if p.NoPreload && !p.templDocLazyLoader.HasLoaded(params.TextDocument) {
+		p.Log.Error("lazy loader has not loaded document", slog.Any("params", params))
+		return nil, nil
+	}
+
 	isTemplFile, goURI := convertTemplToGoURI(params.TextDocument.URI)
 	if !isTemplFile {
 		return p.Target.CodeAction(ctx, params)


### PR DESCRIPTION
When a new Templ file is created, it can take a moment for `GOPACKAGESDRIVER` to detect that the file belongs to a specific Go package—typically after the package clause is added at the top of the file.

Until this happens, any requests that depend on package context, such as `textDocument/codeAction`, are likely to fail. This isn't a problem in isolation, but when a user creates a new file and starts typing before the package is recognized, the client continues to send `textDocument/codeAction` requests on each keystroke. Since the server can't resolve the file's package, each request fails, and the user is bombarded with failure notifications in VS Code, which quickly becomes annoying.

To avoid this, ignore codeAction requests for Templ files that haven't yet been loaded by the lazy loader.