### PR TITLE
refactor: move expressionAttributeValueURL check to separate function rather than have it inline

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1344,7 +1344,7 @@ func (g *generator) writeExpressionAttribute(indentLevel int, elementName string
 	}
 	attrKey := html.EscapeString(attr.Key.String())
 	// Value.
-	if (elementName == "a" && attrKey == "href") || (elementName == "form" && attrKey == "action") {
+	if isExpressionAttributeValueURL(elementName, attrKey) {
 		if err := g.writeExpressionAttributeValueURL(indentLevel, attr); err != nil {
 			return err
 		}
@@ -1788,4 +1788,24 @@ func stripTypes(parameters string) string {
 		variableNames = append(variableNames, strings.TrimSpace(p[0]))
 	}
 	return strings.Join(variableNames, ", ")
+}
+
+func isExpressionAttributeValueURL(elementName, attrName string) bool {
+	var elementAttributeLookup = map[string]string{
+		"a":      "href",
+		"form":   "action",
+		"link":   "href",
+		"object": "data",
+	}
+
+	expectedAttribute, exists := elementAttributeLookup[elementName]
+	if !exists {
+		return false
+	}
+
+	if attrName != expectedAttribute {
+		return false
+	}
+
+	return true
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1797,15 +1797,12 @@ func isExpressionAttributeValueURL(elementName, attrName string) bool {
 		"link":   "href",
 		"object": "data",
 	}
-
 	expectedAttribute, exists := elementAttributeLookup[elementName]
 	if !exists {
 		return false
 	}
-
 	if attrName != expectedAttribute {
 		return false
 	}
-
 	return true
 }

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -70,3 +70,38 @@ templ Hello(name string) {
 		t.Errorf("expected an expression for the package name, template signature (Hello) and for the if (nam), got %#v", op.SourceMap.Expressions)
 	}
 }
+
+func TestIsExpressionAttributeValueURL(t *testing.T) {
+	testCases := []struct {
+		elementName    string
+		attrName       string
+		expectedOutput bool
+	}{
+		{
+			elementName:    "a",
+			attrName:       "href",
+			expectedOutput: true,
+		},
+		{
+			elementName:    "a",
+			attrName:       "class",
+			expectedOutput: false,
+		},
+		{
+			elementName:    "div",
+			attrName:       "class",
+			expectedOutput: false,
+		},
+		{
+			elementName:    "p",
+			attrName:       "href",
+			expectedOutput: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if output := isExpressionAttributeValueURL(testCase.elementName, testCase.attrName); output != testCase.expectedOutput {
+			t.Errorf("expected %t got %t", testCase.expectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
based on #1091

I replaced the inline check in `generator.go`
https://github.com/a-h/templ/blob/15199ff1f8fc2cf6a89f5e21c95d642760735645/generator/generator.go#L1347-L1350

With a separate check function `isExpressionAttributeValueURL` that can be extended to check for any combination of an HTML element type and name of an HTML attribute

The function uses a `map[string]string` to store the element/attribute combinations so it is very easy to add more if needed.

