### PR TITLE
fix: add support for spreading non-string attribute values in RenderAttributes

### DIFF
--- a/generator/test-spread-attributes/render_test.go
+++ b/generator/test-spread-attributes/render_test.go
@@ -111,3 +111,27 @@ func nilPtr[T any]() *T {
 func ptr[T any](x T) *T {
 	return &x
 }
+
+func TestNumericAttributeTypes(t *testing.T) {
+	component := BasicTemplate(templ.Attributes{
+		"int-value":      42,
+		"float-value":    3.14,
+		"uint-value":     uint(100),
+		"int64-value":    int64(9223372036854775807),
+		"complex-value":  complex(1, 2),
+		"string-value":   "text",
+		"bool-true":      true,
+		"bool-false":     false,
+	})
+
+	// Expected output should include all numeric values converted to strings
+	expected := `<div><a bool-true complex-value="(1+2i)" float-value="3.14" int-value="42" int64-value="9223372036854775807" string-value="text" uint-value="100">text</a><div bool-true complex-value="(1+2i)" float-value="3.14" int-value="42" int64-value="9223372036854775807" string-value="text" uint-value="100">text2</div><div>text3</div></div>`
+
+	diff, err := htmldiff.Diff(component, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff != "" {
+		t.Error(diff)
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -483,6 +483,70 @@ func RenderAttributes(ctx context.Context, w io.Writer, attributes Attributer) (
 					return err
 				}
 			}
+		// Integer types
+		case int:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case int8:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case int16:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case int32:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case int64:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		// Unsigned integer types
+		case uint:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case uint8:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case uint16:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case uint32:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case uint64:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case uintptr:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		// Float types
+		case float32:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case float64:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		// Complex types
+		case complex64:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
+		case complex128:
+			if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(fmt.Sprint(value)), `"`); err != nil {
+				return err
+			}
 		case KeyValue[string, bool]:
 			if value.Value {
 				if err = writeStrings(w, ` `, EscapeString(key), `="`, EscapeString(value.Key), `"`); err != nil {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -612,3 +612,117 @@ func TestNonce(t *testing.T) {
 		}
 	})
 }
+
+func TestRenderAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes templ.Attributes
+		expected   string
+	}{
+		{
+			name: "string attributes are rendered",
+			attributes: templ.Attributes{
+				"class": "test-class",
+				"id":    "test-id",
+			},
+			expected: ` class="test-class" id="test-id"`,
+		},
+		{
+			name: "integer types are rendered as strings",
+			attributes: templ.Attributes{
+				"int":   42,
+				"int8":  int8(8),
+				"int16": int16(16),
+				"int32": int32(32),
+				"int64": int64(64),
+			},
+			expected: ` int="42" int16="16" int32="32" int64="64" int8="8"`,
+		},
+		{
+			name: "unsigned integer types are rendered as strings",
+			attributes: templ.Attributes{
+				"uint":    uint(42),
+				"uint8":   uint8(8),
+				"uint16":  uint16(16),
+				"uint32":  uint32(32),
+				"uint64":  uint64(64),
+				"uintptr": uintptr(100),
+			},
+			expected: ` uint="42" uint16="16" uint32="32" uint64="64" uint8="8" uintptr="100"`,
+		},
+		{
+			name: "float types are rendered as strings",
+			attributes: templ.Attributes{
+				"float32": float32(3.14),
+				"float64": float64(2.718),
+			},
+			expected: ` float32="3.14" float64="2.718"`,
+		},
+		{
+			name: "complex types are rendered as strings",
+			attributes: templ.Attributes{
+				"complex64":  complex64(1 + 2i),
+				"complex128": complex128(3 + 4i),
+			},
+			expected: ` complex128="(3+4i)" complex64="(1+2i)"`,
+		},
+		{
+			name: "boolean attributes are rendered correctly",
+			attributes: templ.Attributes{
+				"checked":  true,
+				"disabled": false,
+			},
+			expected: ` checked`,
+		},
+		{
+			name: "mixed types are rendered correctly",
+			attributes: templ.Attributes{
+				"class":  "button",
+				"value":  42,
+				"width":  float64(100.5),
+				"hidden": false,
+				"active": true,
+			},
+			expected: ` active class="button" value="42" width="100.5"`,
+		},
+		{
+			name: "nil pointer attributes are not rendered",
+			attributes: templ.Attributes{
+				"optional": (*string)(nil),
+				"visible":  (*bool)(nil),
+			},
+			expected: ``,
+		},
+		{
+			name: "non-nil pointer attributes are rendered",
+			attributes: templ.Attributes{
+				"title":   stringPtr("test title"),
+				"enabled": boolPtr(true),
+			},
+			expected: ` enabled title="test title"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := templ.RenderAttributes(context.Background(), &buf, tt.attributes)
+			if err != nil {
+				t.Fatalf("RenderAttributes failed: %v", err)
+			}
+
+			actual := buf.String()
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Add support for all numeric types (ints, uints, floats, complex) in RenderAttributes function.

## Changes
- Add support for all numeric types from the stringable interface in RenderAttributes
- Use fmt.Sprint to convert numeric values to strings before rendering  
- Add comprehensive unit tests for RenderAttributes function
- Add integration test for numeric attribute types in spread attributes

## Problem
Previously, only string and boolean values were rendered when using spread attributes. Numeric values like integers and floats were ignored.

## Solution
Extended the switch statement in RenderAttributes to handle all types from the stringable interface by converting them to strings using fmt.Sprint().

## Testing
- All existing tests pass
- New unit tests verify numeric type handling
- Integration test confirms end-to-end functionality

Fixes #1212