### PR TITLE
fix typo in http.ListenAndServer to use middleware

### DIFF
--- a/docs/docs/03-syntax-and-usage/14-context.md
+++ b/docs/docs/03-syntax-and-usage/14-context.md
@@ -169,7 +169,7 @@ func main() {
   h := templ.Handler(Page())
   withMiddleware := Middleware(h)
   http.Handle("/", withMiddleware)
-  http.ListenAndServe(":8080", withMiddleware)
+  http.ListenAndServe(":8080", nil)
 }
 ```
 

--- a/docs/docs/03-syntax-and-usage/14-context.md
+++ b/docs/docs/03-syntax-and-usage/14-context.md
@@ -169,7 +169,7 @@ func main() {
   h := templ.Handler(Page())
   withMiddleware := Middleware(h)
   http.Handle("/", withMiddleware)
-  http.ListenAndServe(":8080", h)
+  http.ListenAndServe(":8080", withMiddleware)
 }
 ```
 


### PR DESCRIPTION
Hello! I have been using templ in a project and could not get the middleware context example to work.
I am quite sure that there is a typo in the documentation, but the same typo is present in issue [#253](https://github.com/a-h/templ/issues/253#issuecomment-1781844381)
It is either a typo, or I am just not understanding something really basic; sorry in advance!

**Before you begin**
templ version 0.3.906

**Describe the bug**
when passing `h` to http.ListenAndServer,  the resulting html is:
`<div class="--templ-css-class-unknown-type">Display</div>` 

when passing `withMiddleware` the resulting html is as expected: 
`<div class="red">Display</div>`

**To Reproduce**
1. create a main.templ file as:
```go
package main 

import (
  "context"
  "net/http"
)

... code in the docs

``` 

2. templ generate
3. go build
4. ./filename
5. visit localhost:8080 


**Screenshots**
<img width="1236" height="870" alt="image" src="https://github.com/user-attachments/assets/7173355b-8bec-4c3f-b6c1-588ba25cf3c5" />

<img width="1260" height="877" alt="image" src="https://github.com/user-attachments/assets/8610c89b-93c1-4bdf-8ad5-9098cf1d3401" />
