### PR TITLE
feat: add Ranges to GoComment parser nodes

### DIFF
--- a/parser/v2/gocommentparser.go
+++ b/parser/v2/gocommentparser.go
@@ -15,6 +15,7 @@ var goSingleLineComment = goSingleLineCommentParser{}
 
 func (p goSingleLineCommentParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 	// Comment start.
+	start := pi.Position()
 	if _, ok, err = goSingleLineCommentStart.Parse(pi); err != nil || !ok {
 		return
 	}
@@ -27,6 +28,7 @@ func (p goSingleLineCommentParser) Parse(pi *parse.Input) (n Node, ok bool, err 
 	}
 	// Return the comment.
 	c.Multiline = false
+	c.Range = NewRange(start, pi.Position())
 	return c, true, nil
 }
 
@@ -57,6 +59,7 @@ func (p goMultiLineCommentParser) Parse(pi *parse.Input) (n Node, ok bool, err e
 	_, _, _ = goMultiLineCommentEnd.Parse(pi)
 	// Return the comment.
 	c.Multiline = true
+	c.Range = NewRange(start, pi.Position())
 	return c, true, nil
 }
 

--- a/parser/v2/gocommentparser_test.go
+++ b/parser/v2/gocommentparser_test.go
@@ -21,6 +21,7 @@ func TestGoCommentParser(t *testing.T) {
 				Contents:  " single line comment",
 				Multiline: false,
 				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 22, Line: 0, Col: 22},
 				},
 			},
@@ -32,6 +33,7 @@ func TestGoCommentParser(t *testing.T) {
 				Contents:  " single line comment",
 				Multiline: false,
 				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 22, Line: 0, Col: 22},
 				},
 			},
@@ -43,6 +45,7 @@ func TestGoCommentParser(t *testing.T) {
 				Contents:  " multiline comment, on one line ",
 				Multiline: true,
 				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 36, Line: 0, Col: 36},
 				},
 			},
@@ -55,6 +58,7 @@ on multiple lines */`,
 				Contents:  " multiline comment,\non multiple lines ",
 				Multiline: true,
 				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 42, Line: 1, Col: 20},
 				},
 			},

--- a/parser/v2/gocommentparser_test.go
+++ b/parser/v2/gocommentparser_test.go
@@ -20,6 +20,9 @@ func TestGoCommentParser(t *testing.T) {
 			expected: &GoComment{
 				Contents:  " single line comment",
 				Multiline: false,
+				Range: Range{
+					To:   Position{Index: 22, Line: 0, Col: 22},
+				},
 			},
 		},
 		{
@@ -28,6 +31,9 @@ func TestGoCommentParser(t *testing.T) {
 			expected: &GoComment{
 				Contents:  " single line comment",
 				Multiline: false,
+				Range: Range{
+					To:   Position{Index: 22, Line: 0, Col: 22},
+				},
 			},
 		},
 		{
@@ -36,6 +42,9 @@ func TestGoCommentParser(t *testing.T) {
 			expected: &GoComment{
 				Contents:  " multiline comment, on one line ",
 				Multiline: true,
+				Range: Range{
+					To:   Position{Index: 36, Line: 0, Col: 36},
+				},
 			},
 		},
 		{
@@ -45,6 +54,9 @@ on multiple lines */`,
 			expected: &GoComment{
 				Contents:  " multiline comment,\non multiple lines ",
 				Multiline: true,
+				Range: Range{
+					To:   Position{Index: 42, Line: 1, Col: 20},
+				},
 			},
 		},
 	}

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -624,7 +624,14 @@ func TestIfExpression(t *testing.T) {
 				},
 				Then: []Node{
 					&Whitespace{Value: "\t\t"},
-					&GoComment{Contents: " this is a comment", Multiline: false},
+					&GoComment{
+						Contents:  " this is a comment",
+						Multiline: false,
+						Range: Range{
+							From: Position{Index: 11, Line: 1, Col: 2},
+							To:   Position{Index: 31, Line: 1, Col: 22},
+						},
+					},
 					&Whitespace{Value: "\n\t"},
 				},
 				Else: []Node{

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -670,7 +670,14 @@ func TestTemplateParser(t *testing.T) {
 				},
 				Children: []Node{
 					&Whitespace{Value: "\t"},
-					&GoComment{Contents: " Comment", Multiline: false},
+					&GoComment{
+						Contents:  " Comment",
+						Multiline: false,
+						Range: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 23, Line: 1, Col: 11},
+						},
+					},
 					&Whitespace{Value: "\n"},
 				},
 			},
@@ -694,7 +701,14 @@ func TestTemplateParser(t *testing.T) {
 				},
 				Children: []Node{
 					&Whitespace{Value: "\t"},
-					&GoComment{Contents: " Comment ", Multiline: true},
+					&GoComment{
+						Contents:  " Comment ",
+						Multiline: true,
+						Range: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 26, Line: 1, Col: 14},
+						},
+					},
 					&Whitespace{Value: "\n"},
 				},
 			},
@@ -720,7 +734,14 @@ func TestTemplateParser(t *testing.T) {
 				},
 				Children: []Node{
 					&Whitespace{Value: "\t"},
-					&GoComment{Contents: " Line 1\n\t\t Line 2\n\t", Multiline: true},
+					&GoComment{
+						Contents:  " Line 1\n\t\t Line 2\n\t",
+						Multiline: true,
+						Range: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 36, Line: 3, Col: 3},
+						},
+					},
 					&Whitespace{Value: "\n"},
 				},
 			},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1117,6 +1117,7 @@ func CopyAttributes(attrs []Attribute) (copies []Attribute) {
 type GoComment struct {
 	Contents  string
 	Multiline bool
+	Range     Range
 }
 
 func (c *GoComment) IsNode() bool { return true }


### PR DESCRIPTION
Hi there, I'm working on a Templ Linting tool for my project. In order to (a) display useful results to users and (b) enable linter config via comments (similar to eslint's `eslint-disable`), the tool needs to be able to understand the original source location of parsed nodes.

I came across a discussion thread on this topic and @joerdav seemed to agree that Templ's own parser should be able to support this: https://github.com/a-h/templ/discussions/586

So, here I am with what I hope to be the first of a handful of pull requests to add `Range`s to various parser nodes. I kept this one small to ensure that I'm following the right conventions, etc. Happy to receive feedback on the PR. I would like to make future PRs a bit longer so I'm not bombarding you with them, but if you prefer many smaller changes that'd fine with me.

Thanks for taking a look!