### PR TITLE
feat: add Range to HTMLComment nodes

### DIFF
--- a/parser/v2/htmlcommentparser.go
+++ b/parser/v2/htmlcommentparser.go
@@ -35,5 +35,6 @@ func (p htmlCommentParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 		return
 	}
 
+	c.Range = NewRange(start, pi.Position())
 	return c, true, nil
 }

--- a/parser/v2/htmlcommentparser_test.go
+++ b/parser/v2/htmlcommentparser_test.go
@@ -18,6 +18,18 @@ func TestHTMLCommentParser(t *testing.T) {
 			input: `<!-- single line comment -->`,
 			expected: &HTMLComment{
 				Contents: " single line comment ",
+				Range: Range{
+					From: Position{
+						Index: 0,
+						Line:  0,
+						Col:   0,
+					},
+					To: Position{
+						Index: 28,
+						Line:  0,
+						Col:   28,
+					},
+				},
 			},
 		},
 		{
@@ -25,6 +37,18 @@ func TestHTMLCommentParser(t *testing.T) {
 			input: `<!--no whitespace between sequence open and close-->`,
 			expected: &HTMLComment{
 				Contents: "no whitespace between sequence open and close",
+				Range: Range{
+					From: Position{
+						Index: 0,
+						Line:  0,
+						Col:   0,
+					},
+					To: Position{
+						Index: 52,
+						Line:  0,
+						Col:   52,
+					},
+				},
 			},
 		},
 		{
@@ -36,6 +60,18 @@ func TestHTMLCommentParser(t *testing.T) {
 				Contents: ` multiline
 								comment
 					`,
+				Range: Range{
+					From: Position{
+						Index: 0,
+						Line:  0,
+						Col:   0,
+					},
+					To: Position{
+						Index: 39,
+						Line:  2,
+						Col:   8,
+					},
+				},
 			},
 		},
 		{
@@ -43,6 +79,18 @@ func TestHTMLCommentParser(t *testing.T) {
 			input: `<!-- <p class="test">tag</p> -->`,
 			expected: &HTMLComment{
 				Contents: ` <p class="test">tag</p> `,
+				Range: Range{
+					From: Position{
+						Index: 0,
+						Line:  0,
+						Col:   0,
+					},
+					To: Position{
+						Index: 32,
+						Line:  0,
+						Col:   32,
+					},
+				},
 			},
 		},
 		{
@@ -50,6 +98,18 @@ func TestHTMLCommentParser(t *testing.T) {
 			input: `<!-- <div> hello world </div> -->`,
 			expected: &HTMLComment{
 				Contents: ` <div> hello world </div> `,
+				Range: Range{
+					From: Position{
+						Index: 0,
+						Line:  0,
+						Col:   0,
+					},
+					To: Position{
+						Index: 33,
+						Line:  0,
+						Col:   33,
+					},
+				},
 			},
 		},
 	}

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -768,9 +768,21 @@ func TestTemplateParser(t *testing.T) {
 				},
 				Children: []Node{
 					&Whitespace{Value: "\t"},
-					&HTMLComment{Contents: " Single line "},
+					&HTMLComment{
+						Contents: " Single line ",
+						Range: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 33, Line: 1, Col: 21},
+						},
+					},
 					&Whitespace{Value: "\n\t"},
-					&HTMLComment{Contents: "\n\t\tMultiline\n\t"},
+					&HTMLComment{
+						Contents: "\n\t\tMultiline\n\t",
+						Range: Range{
+							From: Position{Index: 35, Line: 2, Col: 1},
+							To:   Position{Index: 56, Line: 4, Col: 4},
+						},
+					},
 					&Whitespace{Value: "\n"},
 				},
 			},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1135,6 +1135,7 @@ func (c *GoComment) Visit(v Visitor) error {
 // HTMLComment.
 type HTMLComment struct {
 	Contents string
+	Range    Range
 }
 
 func (c *HTMLComment) IsNode() bool { return true }


### PR DESCRIPTION
Hi again, this adds a `Range` to the parser's `HTMLComment` nodes. 

**Note on testing:** 
I am planning to stick to reusing the existing unit tests and to just update to include ranges. I'm finding that the current set of tests have a good range of inputs. If I spot any missing edge cases, I'll add more tests. Obviously, I'm happy to add any additional tests that you feel are needed as well. Just let me know if you see any gaps.

**Use case notes:**
As [noted previously](https://github.com/a-h/templ/pull/1225), my particular use case for these ranges is for linting Templ code. With each of these PRs I'll add a few words on why a range is useful for this particular element (i.e. why would you want to lint this?)

In the case of HTML comments, you may want to create a rule to forbid them entirely, or at least to ensure that they do not contain commented code. In addition to bloating the payload you send to your visitors, HTML comments may also leak unnecessary information. In most cases -- at least in my organization -- Go comments are preferred.