### PR TITLE
docs: add TrustedOrigins to Gorilla CSRF example

### DIFF
--- a/docs/docs/12-integrations/01-web-frameworks.md
+++ b/docs/docs/12-integrations/01-web-frameworks.md
@@ -60,7 +60,7 @@ func main() {
   r := http.NewServeMux()
   r.Handle("/", templ.Handler(Form()))
 
-  csrfMiddleware := csrf.Protect(mustGenerateCSRFKey())
+  csrfMiddleware := csrf.Protect(mustGenerateCSRFKey(), csrf.TrustedOrigins([]string{"localhost:8000"}))
   withCSRFProtection := csrfMiddleware(r)
 
   fmt.Println("Listening on localhost:8000")


### PR DESCRIPTION
## Summary
- Add `csrf.TrustedOrigins([]string{"localhost:8000"})` to the Gorilla CSRF example
- Prevents "403 - invalid origin" errors when using CSRF middleware with localhost development

## Test plan
- Verify documentation renders correctly
- Confirm CSRF example runs without origin errors when TrustedOrigins is configured

🤖 Generated with [Claude Code](https://claude.ai/code)