### PR TITLE
feat: add Range field to Element parser nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -555,5 +555,6 @@ func addTrailingSpaceAndValidate(start parse.Position, e *Element, pi *parse.Inp
 		return e, false, err
 	}
 
+	e.Range = NewRange(start, pi.Position())
 	return e, true, nil
 }

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -556,6 +556,10 @@ if test {` + " " + `
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 2, Col: 3},
+				},
 			},
 		},
 		{
@@ -579,6 +583,10 @@ if test {` + " " + `
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 23, Line: 2, Col: 3},
 				},
 			},
 		},
@@ -703,6 +711,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 16, Line: 0, Col: 16},
+				},
 			},
 		},
 		{
@@ -713,6 +725,10 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
 			},
 		},
@@ -734,6 +750,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 28, Line: 0, Col: 28},
+				},
 			},
 		},
 		{
@@ -746,6 +766,10 @@ func TestElementParser(t *testing.T) {
 					To:   Position{Index: 6, Line: 0, Col: 6},
 				},
 				Children: nil,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 7, Line: 0, Col: 7},
+				},
 			},
 		},
 		{
@@ -758,6 +782,10 @@ func TestElementParser(t *testing.T) {
 					To:   Position{Index: 3, Line: 0, Col: 3},
 				},
 				Children: nil,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 4, Line: 0, Col: 4},
+				},
 			},
 		},
 		{
@@ -781,6 +809,10 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				Children: nil,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 12, Line: 0, Col: 12},
+				},
 			},
 		},
 		{
@@ -795,6 +827,10 @@ func TestElementParser(t *testing.T) {
 				// <input> is a void element, so text is not a child of the input.
 				// </input> is ignored.
 				Children: nil,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 7, Line: 0, Col: 7},
+				},
 			},
 		},
 		{
@@ -832,6 +868,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 23, Line: 0, Col: 23},
+				},
 			},
 		},
 		{
@@ -850,6 +890,10 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 6, Line: 0, Col: 6},
 							To:   Position{Index: 8, Line: 0, Col: 8},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 9, Line: 0, Col: 9},
+						},
 					},
 					&Element{
 						Name: "br", // The <br></br> one.
@@ -857,7 +901,15 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 10, Line: 0, Col: 10},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+						Range: Range{
+							From: Position{Index: 9, Line: 0, Col: 9},
+							To:   Position{Index: 18, Line: 0, Col: 18},
+						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 24, Line: 0, Col: 24},
 				},
 			},
 		},
@@ -873,6 +925,10 @@ func TestElementParser(t *testing.T) {
 				// <br> is a void element, so <hr> is not a child of the <br>.
 				// </br> is ignored.
 				Children: nil,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 4, Line: 0, Col: 4},
+				},
 			},
 		},
 		{
@@ -910,6 +966,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 20, Line: 0, Col: 20},
+				},
 			},
 		},
 		{
@@ -942,6 +1002,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 45, Line: 0, Col: 45},
 				},
 			},
 		},
@@ -989,6 +1053,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 39, Line: 0, Col: 39},
 				},
 			},
 		},
@@ -1046,6 +1114,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 47, Line: 0, Col: 47},
+				},
 			},
 		},
 		{
@@ -1102,6 +1174,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 83, Line: 0, Col: 83},
 				},
 			},
 		},
@@ -1173,6 +1249,10 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				TrailingSpace: SpaceVertical,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 81, Line: 5, Col: 0},
+				},
 			},
 		},
 		{
@@ -1183,6 +1263,10 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 3, Line: 0, Col: 3},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 5, Line: 0, Col: 5},
 				},
 			},
 		},
@@ -1206,6 +1290,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 28, Line: 0, Col: 28},
 				},
 			},
 		},
@@ -1264,6 +1352,10 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				IndentAttrs: true,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 68, Line: 4, Col: 2},
+				},
 			},
 		},
 		{
@@ -1335,6 +1427,10 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				IndentAttrs: true,
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 104, Line: 6, Col: 2},
+				},
 			},
 		},
 		{
@@ -1401,6 +1497,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 74, Line: 4, Col: 9},
+				},
 			},
 		},
 		{
@@ -1411,6 +1511,10 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 2, Line: 0, Col: 2},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 7, Line: 0, Col: 7},
 				},
 			},
 		},
@@ -1432,6 +1536,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
 			},
 		},
 		{
@@ -1450,7 +1558,15 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 7, Line: 0, Col: 7},
+						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 11, Line: 0, Col: 11},
 				},
 			},
 		},
@@ -1470,7 +1586,15 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 10, Line: 0, Col: 10},
+						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 14, Line: 0, Col: 14},
 				},
 			},
 		},
@@ -1496,7 +1620,15 @@ func TestElementParser(t *testing.T) {
 							&Whitespace{Value: " "},
 						},
 						TrailingSpace: SpaceHorizontal,
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 13, Line: 0, Col: 13},
+						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 17, Line: 0, Col: 17},
 				},
 			},
 		},
@@ -1516,6 +1648,10 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 10, Line: 0, Col: 10},
+						},
 					},
 					&Element{
 						Name: "c",
@@ -1530,9 +1666,21 @@ func TestElementParser(t *testing.T) {
 									From: Position{Index: 14, Line: 0, Col: 14},
 									To:   Position{Index: 15, Line: 0, Col: 15},
 								},
+								Range: Range{
+									From: Position{Index: 13, Line: 0, Col: 13},
+									To:   Position{Index: 17, Line: 0, Col: 17},
+								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 10, Line: 0, Col: 10},
+							To:   Position{Index: 21, Line: 0, Col: 21},
+						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 25, Line: 0, Col: 25},
 				},
 			},
 		},
@@ -1544,6 +1692,10 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 4, Line: 0, Col: 4},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 11, Line: 0, Col: 11},
 				},
 			},
 		},
@@ -1574,6 +1726,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
 			},
 		},
@@ -1662,6 +1818,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 140, Line: 0, Col: 140},
+				},
 			},
 		},
 		{
@@ -1710,6 +1870,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 58, Line: 4, Col: 9},
+				},
 			},
 		},
 		{
@@ -1732,6 +1896,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
 			},
 		},
@@ -1789,6 +1957,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 57, Line: 0, Col: 57},
+				},
 			},
 		},
 		{
@@ -1825,6 +1997,10 @@ func TestElementParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 31, Line: 0, Col: 31},
 				},
 			},
 		},

--- a/parser/v2/forexpressionparser_test.go
+++ b/parser/v2/forexpressionparser_test.go
@@ -164,6 +164,10 @@ func TestForExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 36, Line: 1, Col: 5},
+							To:   Position{Index: 60, Line: 2, Col: 4},
+						},
 					},
 				},
 			},
@@ -217,6 +221,10 @@ func TestForExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 35, Line: 1, Col: 5},
+							To:   Position{Index: 59, Line: 2, Col: 4},
+						},
 					},
 				},
 			},

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -68,6 +68,10 @@ func TestIfExpression(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						Range: Range{
+							From: Position{Index: 12, Line: 1, Col: 0},
+							To:   Position{Index: 48, Line: 4, Col: 0},
+						},
 					},
 				},
 			},
@@ -228,6 +232,10 @@ func TestIfExpression(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						Range: Range{
+							From: Position{Index: 12, Line: 1, Col: 0},
+							To:   Position{Index: 48, Line: 4, Col: 0},
+						},
 					},
 				},
 			},
@@ -368,6 +376,10 @@ func TestIfExpression(t *testing.T) {
 									},
 								},
 								TrailingSpace: SpaceVertical,
+								Range: Range{
+									From: Position{Index: 29, Line: 2, Col: 6},
+									To:   Position{Index: 53, Line: 3, Col: 5},
+								},
 							},
 						},
 					},

--- a/parser/v2/switchexpressionparser_test.go
+++ b/parser/v2/switchexpressionparser_test.go
@@ -107,6 +107,10 @@ default:
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								Range: Range{
+									From: Position{Index: 29, Line: 2, Col: 1},
+									To:   Position{Index: 67, Line: 5, Col: 0},
+								},
 							},
 						},
 					},
@@ -184,6 +188,10 @@ default:
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								Range: Range{
+									From: Position{Index: 36, Line: 2, Col: 0},
+									To:   Position{Index: 72, Line: 5, Col: 0},
+								},
 							},
 						},
 					},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -198,6 +198,10 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 26, Line: 1, Col: 0},
+							To:   Position{Index: 58, Line: 2, Col: 0},
+						},
 					},
 				},
 			},
@@ -252,6 +256,10 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceHorizontal,
+						Range: Range{
+							From: Position{Index: 26, Line: 0, Col: 26},
+							To:   Position{Index: 58, Line: 0, Col: 58},
+						},
 					},
 				},
 			},
@@ -342,10 +350,18 @@ func TestTemplateParser(t *testing.T) {
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								Range: Range{
+									From: Position{Index: 54, Line: 3, Col: 2},
+									To:   Position{Index: 91, Line: 6, Col: 0},
+								},
 							},
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						Range: Range{
+							From: Position{Index: 26, Line: 1, Col: 0},
+							To:   Position{Index: 98, Line: 7, Col: 0},
+						},
 					},
 				},
 			},
@@ -428,6 +444,10 @@ func TestTemplateParser(t *testing.T) {
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								Range: Range{
+									From: Position{Index: 41, Line: 2, Col: 2},
+									To:   Position{Index: 81, Line: 5, Col: 1},
+								},
 							},
 						},
 					},
@@ -494,6 +514,10 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 27, Line: 1, Col: 1},
+							To:   Position{Index: 60, Line: 2, Col: 1},
+						},
 					},
 					&Element{
 						Name: "input",
@@ -524,6 +548,10 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 60, Line: 2, Col: 1},
+							To:   Position{Index: 92, Line: 3, Col: 0},
+						},
 					},
 				},
 			},
@@ -647,6 +675,10 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 57, Line: 2, Col: 0},
+						},
 					},
 				},
 			},
@@ -846,6 +878,10 @@ func TestTemplateParser(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						Range: Range{
+							From: Position{Index: 42, Line: 1, Col: 2},
+							To:   Position{Index: 94, Line: 4, Col: 0},
+						},
 					},
 				},
 			},
@@ -876,6 +912,10 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 19, Line: 1, Col: 4},
 						},
 						TrailingSpace: SpaceNone,
+						Range: Range{
+							From: Position{Index: 16, Line: 1, Col: 1},
+							To:   Position{Index: 25, Line: 1, Col: 10},
+						},
 					},
 					&Element{
 						Name: "br",
@@ -884,6 +924,10 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 28, Line: 1, Col: 13},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 25, Line: 1, Col: 10},
+							To:   Position{Index: 30, Line: 2, Col: 0},
+						},
 					},
 				},
 			},

--- a/parser/v2/templelementparser_test.go
+++ b/parser/v2/templelementparser_test.go
@@ -158,6 +158,10 @@ func TestTemplElementExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 19, Line: 1, Col: 3},
+							To:   Position{Index: 42, Line: 2, Col: 2},
+						},
 					},
 				},
 			},
@@ -411,6 +415,10 @@ func TestTemplElementExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 38, Line: 1, Col: 2},
+							To:   Position{Index: 55, Line: 2, Col: 0},
+						},
 					},
 				},
 			},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -497,6 +497,7 @@ type Element struct {
 	IndentChildren bool
 	TrailingSpace  TrailingSpace
 	NameRange      Range
+	Range          Range
 }
 
 func (e Element) Trailing() TrailingSpace {


### PR DESCRIPTION
Hi again, back with another `Range` addition. This is the big one, haha.

Thank you for the reviews!

**Use case notes:** As mentioned previously, I'm working on a linting tool for Templ. `Element` seems like the most obvious in terms of being generally useful for such a tool, but I'll also throw out a few things in particular I'm thinking of.

- Disallow certain elements entirely: For example, `<iframe>`s. Or, in our case, we plan to have our own custom element replacements for certain tags to ensure compatibility and accessibility for clients and we want to ensure folks can't use the standard elements.
- Require certain attributes to be present: Obvious cases are `alt` for `<img>` and `href` for `<a>`. (I realize that dynamic attributes can make this challenging/impossible.)
- Prevent invalid HTML: For example, nesting interactive elements (e.g. putting an `<a>` inside another `<a>`) is invalid HTML and can lead to unexpected behavior.