### PR TITLE
fix: skip parsing of JavaScript regexp literals: `/test/`

### DIFF
--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -317,7 +317,13 @@ var regexpLiteral = parse.Func(func(in *parse.Input) (regexp string, ok bool, er
 				if ok {
 					literal.WriteString(flags)
 				}
-				return literal.String(), true, nil
+				output := literal.String()
+				if strings.Contains(output, "{{") && strings.Contains(output, "}}") {
+					// If the regex contains a Go expression, don't treat it as a regex literal.
+					in.Seek(startIndex)
+					return "", false, nil
+				}
+				return output, true, nil
 			}
 		}
 	}

--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -310,22 +310,17 @@ var regexpLiteral = parse.Func(func(in *parse.Input) (regexp string, ok bool, er
 			if !inClass {
 				// We've reached the end of the regex, but there may be flags after it.
 				// Read flags until we hit a non-flag character.
-			flagsLoop:
-				for {
-					s, ok := in.Peek(1)
-					if !ok || !strings.ContainsAny(s, "gimuy") {
-						break flagsLoop
-					}
-					s, ok = in.Take(1)
-					if !ok {
-						// Restore position if no flags.
-						in.Seek(startIndex)
-						return "", false, nil
-					}
-					literal.WriteString(s)
+				flags, ok, err := regexpFlags.Parse(in)
+				if err != nil {
+					return "", false, err
+				}
+				if ok {
+					literal.WriteString(flags)
 				}
 				return literal.String(), true, nil
 			}
 		}
 	}
 })
+
+var regexpFlags = parse.StringFrom(parse.Repeat(0, 5, parse.RuneIn("gimuy")))

--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -151,7 +151,7 @@ loop:
 				return nil, false, err
 			}
 			if !ok {
-				continue charLoop
+				return nil, false, parse.Error("script: expected to parse a character, but didn't", pi.Position())
 			}
 			if c == string(jsQuoteDouble) || c == string(jsQuoteSingle) || c == string(jsQuoteBacktick) {
 				// Start or exit a string literal.
@@ -161,14 +161,13 @@ loop:
 					stringLiteralDelimiter = jsQuoteNone
 				}
 			}
-			peeked, _ := pi.Peek(1)
-			peeked = c + peeked
 
-			_, isEOF, _ := parse.EOF[string]().Parse(pi)
+			peeked, peekOK := pi.Peek(1)
+			isEOF := !peekOK
+			peeked = c + peeked
 			breakForGo := peeked == "{{"
 			breakForHTML := stringLiteralDelimiter == jsQuoteNone && peeked == "</"
 			breakForComment := stringLiteralDelimiter == jsQuoteNone && (peeked == "//" || peeked == "/*")
-
 			if isEOF || breakForGo || breakForHTML || breakForComment {
 				if sb.Len() > 0 {
 					e.Contents = append(e.Contents, NewScriptContentsScriptCode(sb.String()))
@@ -180,6 +179,7 @@ loop:
 				pi.Seek(before)
 				continue loop
 			}
+
 			sb.WriteString(c)
 		}
 	}

--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -32,30 +32,29 @@ func (p scriptElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error)
 	var name string
 	if name, ok, err = elementNameParser.Parse(pi); err != nil || !ok {
 		pi.Seek(start)
-		return
+		return n, false, err
 	}
 
 	if name != "script" {
 		pi.Seek(start)
-		ok = false
-		return
+		return n, false, nil
 	}
 
 	if e.Attributes, ok, err = (attributesParser{}).Parse(pi); err != nil || !ok {
 		pi.Seek(start)
-		return
+		return n, false, err
 	}
 
 	// Optional whitespace.
 	if _, _, err = parse.OptionalWhitespace.Parse(pi); err != nil {
 		pi.Seek(start)
-		return
+		return n, false, err
 	}
 
 	// >
 	if _, ok, err = gt.Parse(pi); err != nil || !ok {
 		pi.Seek(start)
-		return
+		return n, false, parse.Error("<script>: unclosed element - missing '>'", pi.Position())
 	}
 
 	// If there's a type attribute and it's not a JS attribute (e.g. text/javascript), we need to parse the contents as raw text.
@@ -89,18 +88,25 @@ loop:
 		//  - \ - Start of an escape sequence, we can just take the value.
 		//  - Anything else - Add it to the script.
 
-		if _, ok, err = jsEndTag.Parse(pi); err != nil || ok {
+		_, ok, err = jsEndTag.Parse(pi)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
 			// We've reached the end of the script.
 			break loop
 		}
 
-		if _, ok, err = endTagStart.Parse(pi); err != nil || ok {
-			// We've reached the end of the script, but the end tag is probably invalid.
-			break loop
+		_, ok, err = endTagStart.Parse(pi)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return nil, false, parse.Error("<script>: invalid end tag, expected </script> not found", pi.Position())
 		}
 
-		var code Node
-		code, ok, err = goCodeInJavaScript.Parse(pi)
+		// Try for a Go code expression, i.e. {{ goCode }}.
+		code, ok, err := goCodeInJavaScript.Parse(pi)
 		if err != nil {
 			return nil, false, err
 		}
@@ -110,8 +116,7 @@ loop:
 		}
 
 		// Try for a comment.
-		var comment string
-		comment, ok, err = jsComment.Parse(pi)
+		comment, ok, err := jsComment.Parse(pi)
 		if err != nil {
 			return nil, false, err
 		}
@@ -120,17 +125,27 @@ loop:
 			continue loop
 		}
 
-		// Read JavaScript chracaters.
+		// Read JavaScript characters.
 		for {
 			before := pi.Index()
-			var c string
+
+			// Check for a regular expression literal.
+			r, ok, err := regexpLiteral.Parse(pi)
+			if err != nil {
+				return nil, false, err
+			}
+			if ok {
+				sb.WriteString(r)
+				continue
+			}
+
+			// Check for a character.
 			c, ok, err := jsCharacter.Parse(pi)
 			if err != nil {
 				return nil, false, err
 			}
 			if ok {
-				_, isEOF, _ := parse.EOF[string]().Parse(pi)
-				if c == `"` || c == "'" || c == "`" {
+				if c == string(jsQuoteDouble) || c == string(jsQuoteSingle) || c == string(jsQuoteBacktick) {
 					// Start or exit a string literal.
 					if stringLiteralDelimiter == jsQuoteNone {
 						stringLiteralDelimiter = jsQuote(c)
@@ -141,10 +156,12 @@ loop:
 				peeked, _ := pi.Peek(1)
 				peeked = c + peeked
 
+				_, isEOF, _ := parse.EOF[string]().Parse(pi)
 				breakForGo := peeked == "{{"
-				breakForHTML := stringLiteralDelimiter == jsQuoteNone && (peeked == "</" || peeked == "//" || peeked == "/*")
+				breakForHTML := stringLiteralDelimiter == jsQuoteNone && peeked == "</"
+				breakForComment := stringLiteralDelimiter == jsQuoteNone && (peeked == "//" || peeked == "/*")
 
-				if isEOF || breakForGo || breakForHTML {
+				if isEOF || breakForGo || breakForHTML || breakForComment {
 					if sb.Len() > 0 {
 						e.Contents = append(e.Contents, NewScriptContentsScriptCode(sb.String()))
 						sb.Reset()
@@ -238,3 +255,73 @@ var (
 	jsEndOfMultiLineComment = parse.StringFrom(parse.Or(parse.String("*/"), parse.EOF[string]()))
 	jsMultiLineComment      = parse.StringFrom(jsStartMultiLineComment, parse.StringUntil(jsEndOfMultiLineComment), jsEndOfMultiLineComment, parse.OptionalWhitespace)
 )
+
+var regexpLiteral = parse.Func(func(in *parse.Input) (regexp string, ok bool, err error) {
+	startIndex := in.Index()
+
+	// Take the initial '/'.
+	s, ok := in.Take(1)
+	if !ok || s != "/" {
+		in.Seek(startIndex)
+		return "", false, nil
+	}
+	// Peek the next char. If it's also a '/', then this is not a regex literal, but the start of a comment.
+	p, ok := in.Peek(1)
+	if !ok || p == "/" {
+		in.Seek(startIndex)
+		return "", false, nil
+	}
+	var literal strings.Builder
+	literal.WriteString(s)
+
+	var inClass, escaped bool
+
+	for {
+		s, ok := in.Take(1)
+		if !ok {
+			// Restore position if no closing '/'.
+			in.Seek(startIndex)
+			return "", false, nil
+		}
+
+		literal.WriteString(s)
+
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		switch s {
+		case "\n", "\r":
+			// Newline in a regex is not allowed, so we restore the position and return false.
+			in.Seek(startIndex)
+			return "", false, nil
+		case "\\":
+			escaped = true
+		case "[":
+			inClass = true
+		case "]":
+			inClass = false
+		case "/":
+			if !inClass {
+				// We've reached the end of the regex, but there may be flags after it.
+				// Read flags until we hit a non-flag character.
+			flagsLoop:
+				for {
+					s, ok := in.Peek(1)
+					if !ok || !strings.ContainsAny(s, "gimuy") {
+						break flagsLoop
+					}
+					s, ok = in.Take(1)
+					if !ok {
+						// Restore position if no flags.
+						in.Seek(startIndex)
+						return "", false, nil
+					}
+					literal.WriteString(s)
+				}
+				return literal.String(), true, nil
+			}
+		}
+	}
+})

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -383,6 +383,31 @@ set tier_1 to #tier-1's value
 				},
 			},
 		},
+		{
+			name: "regexp expressions",
+			input: `<script>
+const result = call(1000 / 10, {{ data }}, 1000 / 10);
+</script>`,
+			expected: &ScriptElement{
+				Contents: []ScriptContents{
+					NewScriptContentsScriptCode("\nconst result = call(1000 / 10, "),
+					NewScriptContentsGo(&GoCode{
+						Expression: Expression{
+							Value: "data",
+							Range: Range{
+								From: Position{Index: 43, Line: 1, Col: 34},
+								To:   Position{Index: 47, Line: 1, Col: 38},
+							},
+						},
+					}, false),
+					NewScriptContentsScriptCode(", 1000 / 10);\n"),
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 73, Line: 2, Col: 9},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -464,6 +489,12 @@ func TestScriptElementRegexpParser(t *testing.T) {
 		{
 			name:       "no match: missing opening slash",
 			input:      `a|b/`,
+			expected:   "",
+			expectedOK: false,
+		},
+		{
+			name:       "must not contain interpolated go expressions",
+			input:      `/a{{ b }}/`,
 			expected:   "",
 			expectedOK: false,
 		},

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -513,9 +513,6 @@ func TestScriptElementRegexpParser(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
-			if ok != tt.expectedOK {
-				t.Errorf("expected ok to be %v, got %v", tt.expectedOK, ok)
-			}
 		})
 	}
 }

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -54,8 +54,8 @@ func TestScriptElementParserPlain(t *testing.T) {
 			}
 
 			expected := clean(a.Files[1].Data)
-			if diff := cmp.Diff(actual.String(), string(expected)); diff != "" {
-				t.Fatalf("%s:\n%s", file, diff)
+			if diff := cmp.Diff(string(expected), actual.String()); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}
@@ -68,7 +68,7 @@ func TestScriptElementParser(t *testing.T) {
 		expected *ScriptElement
 	}{
 		{
-			name:  "script: no content",
+			name:  "no content",
 			input: `<script></script>`,
 			expected: &ScriptElement{
 				Range: Range{
@@ -78,7 +78,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: vbscript",
+			name:  "vbscript",
 			input: `<script type="vbscript">dim x = 1</script>`,
 			expected: &ScriptElement{
 				Attributes: []Attribute{
@@ -99,7 +99,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression",
+			name:  "go expression",
 			input: `<script>{{ name }}</script>`,
 			expected: &ScriptElement{
 				Contents: []ScriptContents{
@@ -120,7 +120,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression with explicit type",
+			name:  "go expression with explicit type",
 			input: `<script type="text/javascript">{{ name }}</script>`,
 			expected: &ScriptElement{
 				Attributes: []Attribute{&ConstantAttribute{
@@ -150,7 +150,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression with module type",
+			name:  "go expression with module type",
 			input: `<script type="module">{{ name }}</script>`,
 			expected: &ScriptElement{
 				Attributes: []Attribute{&ConstantAttribute{
@@ -180,7 +180,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression with javascript type",
+			name:  "go expression with javascript type",
 			input: `<script type="javascript">{{ name }}</script>`,
 			expected: &ScriptElement{
 				Attributes: []Attribute{&ConstantAttribute{
@@ -210,7 +210,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name: "script: go expression - multiline 1",
+			name: "go expression - multiline 1",
 			input: `<script>
 {{ name }}
 </script>`,
@@ -235,7 +235,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression in single quoted string",
+			name:  "go expression in single quoted string",
 			input: `<script>var x = '{{ name }}';</script>`,
 			expected: &ScriptElement{
 				Contents: []ScriptContents{
@@ -258,7 +258,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name:  "script: go expression in double quoted string",
+			name:  "go expression in double quoted string",
 			input: `<script>var x = "{{ name }}";</script>`,
 			expected: &ScriptElement{
 				Contents: []ScriptContents{
@@ -281,7 +281,7 @@ func TestScriptElementParser(t *testing.T) {
 			},
 		},
 		{
-			name: "script: go expression in double quoted multiline string",
+			name: "go expression in double quoted multiline string",
 			input: `<script>var x = "This is a test \
 {{ name }} \
 to see if it works";</script>`,
@@ -307,7 +307,7 @@ to see if it works";</script>`,
 			},
 		},
 		{
-			name:  "script: go expression in backtick quoted string",
+			name:  "go expression in backtick quoted string",
 			input: `<script>var x = ` + "`" + "{{ name }}" + "`" + `;</script>`,
 			expected: &ScriptElement{
 				Contents: []ScriptContents{
@@ -330,7 +330,7 @@ to see if it works";</script>`,
 			},
 		},
 		{
-			name: "script: single line commented out go expressions are ignored",
+			name: "single line commented out go expressions are ignored",
 			input: `<script>
 // {{ name }}
 </script>`,
@@ -346,7 +346,7 @@ to see if it works";</script>`,
 			},
 		},
 		{
-			name: "script: multiline commented out go expressions are ignored",
+			name: "multiline commented out go expressions are ignored",
 			input: `<script>
 /* There's some content
 {{ name }}
@@ -364,7 +364,7 @@ but it's commented out */
 			},
 		},
 		{
-			name: "script: non js content is parsed raw",
+			name: "non js content is parsed raw",
 			input: `<script type="text/hyperscript">
 set tier_1 to #tier-1's value
 </script>`,
@@ -385,8 +385,8 @@ set tier_1 to #tier-1's value
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			input := parse.NewInput(tt.input)
 			result, ok, err := scriptElement.Parse(input)
 			if err != nil {
@@ -397,6 +397,93 @@ set tier_1 to #tier-1's value
 			}
 			if diff := cmp.Diff(tt.expected, result); diff != "" {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestScriptElementRegexpParser(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		expected   string
+		expectedOK bool
+	}{
+		{
+			name:       "no content is considered to be a comment",
+			input:      `//`,
+			expectedOK: false,
+		},
+		{
+			name:       "must not be multiline",
+			input:      "/div>\n</div>",
+			expectedOK: false,
+		},
+		{
+			name:       "match a single char",
+			input:      `/a/`,
+			expected:   `/a/`,
+			expectedOK: true,
+		},
+		{
+			name:       "match a simple regex",
+			input:      `/a|b/`,
+			expected:   `/a|b/`,
+			expectedOK: true,
+		},
+		{
+			name:       "match a complex regex",
+			input:      `/a(b|c)*d{2,4}/`,
+			expected:   `/a(b|c)*d{2,4}/`,
+			expectedOK: true,
+		},
+		{
+			name:       "match a regex with flags",
+			input:      `/a/i`,
+			expected:   `/a/i`,
+			expectedOK: true,
+		},
+		{
+			name:       "match a regex with multiple flags",
+			input:      `/a/gmi`,
+			expected:   `/a/gmi`,
+			expectedOK: true,
+		},
+		{
+			name:       "escaped slashes",
+			input:      `/a\/b\/c/`,
+			expected:   `/a\/b\/c/`,
+			expectedOK: true,
+		},
+		{
+			name:       "no match: missing closing slash",
+			input:      `/a|b`,
+			expected:   "",
+			expectedOK: false,
+		},
+		{
+			name:       "no match: missing opening slash",
+			input:      `a|b/`,
+			expected:   "",
+			expectedOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := parse.NewInput(tt.input)
+			result, ok, err := regexpLiteral.Parse(input)
+			if err != nil {
+				t.Fatalf("parser error: %v", err)
+			}
+			if ok != tt.expectedOK {
+				t.Fatalf("expected ok to be %v, got %v", tt.expectedOK, ok)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+			if ok != tt.expectedOK {
+				t.Errorf("expected ok to be %v, got %v", tt.expectedOK, ok)
 			}
 		})
 	}

--- a/parser/v2/scriptparsertestdata/regexp_literal.txt
+++ b/parser/v2/scriptparsertestdata/regexp_literal.txt
@@ -1,0 +1,10 @@
+-- in --
+<script>
+const regex = /data-client-id="([^"]+)"/;
+const clientIdMatch = evt.detail.message.match(regex);
+</script>
+-- out --
+
+const regex = /data-client-id="([^"]+)"/;
+const clientIdMatch = evt.detail.message.match(regex);
+


### PR DESCRIPTION
Fixes https://github.com/a-h/templ/issues/1243

But introduces an issue in code like this:

```
const result = call(1000 / 10, {{ data }}, 1000 / 10);
```

In the current PR, `/ 100, {{ data }}, 1000 /` would be collected as a regexp literal, and therefore, the `{{ data }}` go value wouldn't be interpolated.