### PR TITLE
Add `Range`s to `IfExpression` and `ElseIfExpression`parser nodes

### DIFF
--- a/parser/v2/ifexpressionparser.go
+++ b/parser/v2/ifexpressionparser.go
@@ -67,6 +67,7 @@ func (ifExpressionParser) Parse(pi *parse.Input) (n Node, matched bool, err erro
 		return r, true, parse.Error("if: expected closing brace", pi.Position())
 	}
 
+	r.Range = NewRange(pi.PositionAt(start), pi.Position())
 	return r, true, nil
 }
 

--- a/parser/v2/ifexpressionparser.go
+++ b/parser/v2/ifexpressionparser.go
@@ -109,6 +109,7 @@ func (elseIfExpressionParser) Parse(pi *parse.Input) (r ElseIfExpression, matche
 	}
 	r.Then = thenNodes.Nodes
 
+	r.Range = NewRange(pi.PositionAt(start), pi.Position())
 	return r, true, nil
 }
 

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -465,6 +465,10 @@ func TestIfExpression(t *testing.T) {
 								TrailingSpace: SpaceVertical,
 							},
 						},
+						Range: Range{
+							From: Position{Index: 18, Line: 2, Col: 0},
+							To:   Position{Index: 43, Line: 4, Col: 0},
+						},
 					},
 				},
 				Range: Range{
@@ -525,6 +529,10 @@ func TestIfExpression(t *testing.T) {
 								TrailingSpace: SpaceVertical,
 							},
 						},
+						Range: Range{
+							From: Position{Index: 18, Line: 2, Col: 0},
+							To:   Position{Index: 43, Line: 4, Col: 0},
+						},
 					},
 					{
 						Expression: Expression{
@@ -546,6 +554,10 @@ func TestIfExpression(t *testing.T) {
 								},
 								TrailingSpace: SpaceVertical,
 							},
+						},
+						Range: Range{
+							From: Position{Index: 43, Line: 4, Col: 0},
+							To:   Position{Index: 68, Line: 6, Col: 0},
 						},
 					},
 				},
@@ -609,6 +621,10 @@ func TestIfExpression(t *testing.T) {
 								TrailingSpace: SpaceVertical,
 							},
 						},
+						Range: Range{
+							From: Position{Index: 18, Line: 2, Col: 0},
+							To:   Position{Index: 43, Line: 4, Col: 0},
+						},
 					},
 					{
 						Expression: Expression{
@@ -630,6 +646,10 @@ func TestIfExpression(t *testing.T) {
 								},
 								TrailingSpace: SpaceVertical,
 							},
+						},
+						Range: Range{
+							From: Position{Index: 43, Line: 4, Col: 0},
+							To:   Position{Index: 68, Line: 6, Col: 0},
 						},
 					},
 				},

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -74,6 +74,10 @@ func TestIfExpression(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 49, Line: 4, Col: 1},
+				},
 			},
 		},
 		{
@@ -140,6 +144,10 @@ func TestIfExpression(t *testing.T) {
 						TrailingSpace: SpaceVertical,
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 37, Line: 4, Col: 1},
+				},
 			},
 		},
 		{
@@ -174,6 +182,10 @@ func TestIfExpression(t *testing.T) {
 						},
 						TrailingSpace: SpaceVertical,
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 2, Col: 1},
 				},
 			},
 		},
@@ -237,6 +249,10 @@ func TestIfExpression(t *testing.T) {
 							To:   Position{Index: 48, Line: 4, Col: 0},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 49, Line: 4, Col: 1},
 				},
 			},
 		},
@@ -303,6 +319,10 @@ func TestIfExpression(t *testing.T) {
 						},
 						TrailingSpace: SpaceVertical,
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 36, Line: 4, Col: 1},
 				},
 			},
 		},
@@ -382,8 +402,16 @@ func TestIfExpression(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 14, Line: 1, Col: 5},
+							To:   Position{Index: 54, Line: 3, Col: 6},
+						},
 					},
 					&Whitespace{Value: "\n\t\t\t\t"},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 60, Line: 4, Col: 5},
 				},
 			},
 		},
@@ -438,6 +466,10 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 44, Line: 4, Col: 1},
 				},
 			},
 		},
@@ -516,6 +548,10 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 69, Line: 6, Col: 1},
 				},
 			},
 		},
@@ -609,6 +645,10 @@ func TestIfExpression(t *testing.T) {
 						TrailingSpace: SpaceVertical,
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 87, Line: 8, Col: 1},
+				},
 			},
 		},
 		{
@@ -665,6 +705,10 @@ func TestIfExpression(t *testing.T) {
 						},
 						TrailingSpace: SpaceVertical,
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 54, Line: 4, Col: 2},
 				},
 			},
 		},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -450,6 +450,10 @@ func TestTemplateParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 27, Line: 1, Col: 1},
+							To:   Position{Index: 82, Line: 5, Col: 2},
+						},
 					},
 					&Whitespace{
 						Value: "\n",

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1260,6 +1260,7 @@ type IfExpression struct {
 	Then       []Node
 	ElseIfs    []ElseIfExpression
 	Else       []Node
+	Range      Range
 }
 
 type ElseIfExpression struct {

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1266,6 +1266,7 @@ type IfExpression struct {
 type ElseIfExpression struct {
 	Expression Expression
 	Then       []Node
+	Range      Range
 }
 
 func (n IfExpression) ChildNodes() []Node {


### PR DESCRIPTION
Hi there, back with another set of `Range` additions, this time for `IfExpression` and `ElseIfExpression`parser nodes.

I'll forgo the additional linter use notes unless you'd like me to add that context. 

Thank you very much for the reviews!