### PR TITLE
docs: update tailwind with v4

### DIFF
--- a/docs/docs/09-developer-tools/04-live-reload-with-other-tools.md
+++ b/docs/docs/09-developer-tools/04-live-reload-with-other-tools.md
@@ -47,10 +47,22 @@ This assumes that your http server is running on `http://localhost:8080`. `--ope
 
 ### Tailwind CSS
 
-Tailwind requires a `tailwind.config.js` file at the root of your project, alongside an `input.css` file.
+Tailwind can be installed via your preferred package manager. The `@tailwindcss/cli` package requires `tailwindcss` as a local peer dependency, `tailwindcss` cannot be installed globally.
 
 ```bash
-npx --yes tailwindcss -i ./input.css -o ./assets/styles.css --minify --watch
+npm install tailwindcss @tailwindcss/cli
+```
+
+Tailwind requires some input CSS file, e.g. `input.css` with the following directive:
+
+```css
+@import "tailwindcss";
+```
+
+Then you can use the `@tailwindcss/cli` package to generate the css bundle.
+
+```bash
+npx --yes @tailwindcss/cli -i ./input.css -o ./assets/styles.css --minify --watch
 ```
 
 This will watch `input.css` as well as your `.templ` files and re-generate `assets/styles.css` whenever there's a change.


### PR DESCRIPTION
With tailwind v4, the [docs ](https://tailwindcss.com/docs/installation/tailwind-cli)on it have changed a bit. Namely
1) The `tailwindcss` package no longer is contains the CLI to watch/generate the css bundle. It is now `@tailwindcss/cli`.
    a) The `@tailwind/css` package requires `tailwindcss` as a dependency. It unfortunately cannot detect the `tailwindcss` package when the `tailwindcss` is installed globally. [This ](https://github.com/tailwindlabs/tailwindcss/discussions/6645)is the only discussion on their side I could find.
2) It no longer requires the `tailwindcss.config.js` file.

Words are hard, so I'm open to any suggestions in wording. This was confusing me when setting up a new project