### PR TITLE
ci: typo generate

### DIFF
--- a/examples/suspense/main_templ.go
+++ b/examples/suspense/main_templ.go
@@ -18,7 +18,7 @@ func main() {
 		// Create a channel to send deferred component renders to the template.
 		data := make(chan SlotContents)
 
-		// We know there are 3 slots, so start a WaitGround.
+		// We know there are 3 slots, so start a WaitGroup.
 		var wg sync.WaitGroup
 		wg.Add(3)
 


### PR DESCRIPTION
Runs generate after #1270 broke it

<img width="1798" height="859" alt="image" src="https://github.com/user-attachments/assets/0a2c5655-7195-4747-b245-a268701fd29e" />
