### PR TITLE
feat: add `Range` to `CallTemplateExpression` nodes

### DIFF
--- a/parser/v2/calltemplateparser.go
+++ b/parser/v2/calltemplateparser.go
@@ -12,6 +12,8 @@ var callTemplateExpressionStart = parse.Or(parse.String("{! "), parse.String("{!
 type callTemplateExpressionParser struct{}
 
 func (p callTemplateExpressionParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
+	start := pi.Position()
+
 	// Check the prefix first.
 	if _, ok, err = callTemplateExpressionStart.Parse(pi); err != nil || !ok {
 		return
@@ -28,6 +30,8 @@ func (p callTemplateExpressionParser) Parse(pi *parse.Input) (n Node, ok bool, e
 		err = parse.Error("call template expression: missing closing brace", pi.Position())
 		return
 	}
+
+	r.Range = NewRange(start, pi.Position())
 
 	return r, true, nil
 }

--- a/parser/v2/calltemplateparser_test.go
+++ b/parser/v2/calltemplateparser_test.go
@@ -32,6 +32,10 @@ func TestCallTemplateExpressionParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 18, Line: 0, Col: 18},
+				},
 			},
 		},
 		{
@@ -53,6 +57,10 @@ func TestCallTemplateExpressionParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 17, Line: 0, Col: 17},
+				},
 			},
 		},
 		{
@@ -73,6 +81,10 @@ func TestCallTemplateExpressionParser(t *testing.T) {
 							Col:   15,
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 16, Line: 0, Col: 16},
 				},
 			},
 		},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1159,6 +1159,7 @@ func (c *HTMLComment) Visit(v Visitor) error {
 type CallTemplateExpression struct {
 	// Expression returns a template to execute.
 	Expression Expression
+	Range      Range
 }
 
 func (cte *CallTemplateExpression) IsNode() bool { return true }


### PR DESCRIPTION
Hi again, adding more `Range`s to parser nodes. `CallTemplateExpression` this time. About 2/3 of the way through!