### PR TITLE
docs: update Air version in live reload example Makefile

### DIFF
--- a/docs/docs/09-developer-tools/04-live-reload-with-other-tools.md
+++ b/docs/docs/09-developer-tools/04-live-reload-with-other-tools.md
@@ -82,7 +82,7 @@ This will watch `js/index.ts` and relevant files, and re-generate `assets/index.
 To watch and restart your Go server, when only the `go` files change you can use `air`:
 
 ```bash
-go run github.com/air-verse/air@v1.51.0 \
+go run github.com/air-verse/air@v1.63.0 \
   --build.cmd "go build -o tmp/bin/main" --build.bin "tmp/bin/main" --build.delay "100" \
   --build.exclude_dir "node_modules" \
   --build.include_ext "go" \
@@ -109,7 +109,7 @@ We also want the browser to automatically reload when the:
 To trigger the event, we can use the `air` command to use a different set of options, using the `templ` CLI to send a reload event to the browser.
 
 ```bash
-go run github.com/air-verse/air@v1.51.0 \
+go run github.com/air-verse/air@v1.63.0 \
   --build.cmd "templ generate --notify-proxy" \
   --build.bin "true" \
   --build.delay "100" \
@@ -187,7 +187,7 @@ live/templ:
 
 # run air to detect any go file changes to re-build and re-run the server.
 live/server:
-	go run github.com/air-verse/air@v1.51.0 \
+	go run github.com/air-verse/air@v1.63.0 \
 	--build.cmd "go build -o tmp/bin/main" --build.bin "tmp/bin/main" --build.delay "100" \
 	--build.exclude_dir "node_modules" \
 	--build.include_ext "go" \
@@ -204,7 +204,7 @@ live/esbuild:
 
 # watch for any js or css change in the assets/ folder, then reload the browser via templ proxy.
 live/sync_assets:
-	go run github.com/air-verse/air@v1.51.0 \
+	go run github.com/air-verse/air@v1.63.0 \
 	--build.cmd "templ generate --notify-proxy" \
 	--build.bin "true" \
 	--build.delay "100" \


### PR DESCRIPTION
Using the [live reload example Makefile](https://templ.guide/developer-tools/live-reload-with-other-tools#putting-it-all-together), I was getting this error:

```
go: github.com/air-verse/air@v1.51.0: version constraints conflict:
	github.com/air-verse/air@v1.51.0: parsing go.mod:
	module declares its path as: github.com/cosmtrek/air
	        but was required as: github.com/air-verse/air
```

It looks like the v1.52.2 release fixes the naming error via https://github.com/air-verse/air/pull/602 but I did update to the current latest release while we're here.