### PR TITLE
fix: prevent templ fmt from adding whitespace to blank lines in inline functions

### DIFF
--- a/internal/format/testdata/inline_func_blank_lines_no_whitespace.txt
+++ b/internal/format/testdata/inline_func_blank_lines_no_whitespace.txt
@@ -1,0 +1,88 @@
+-- in --
+package main
+
+type Params struct {
+	Foo string
+}
+
+templ Child(p Params) {
+	<p>{ p.Foo }</p>
+}
+
+templ Parent(p Params) {
+	{{
+		bar := (func() string {
+			if p.Foo == "" {
+				return "Bar"
+			}
+
+			return p.Foo
+		})()
+		baz := Params{
+			Foo: (func() string {
+				if p.Foo == "" {
+					return "Baz"
+				}
+
+				return p.Foo
+			})(),
+		}
+	}}
+	<div>
+		@Child(Params{
+			Foo: (func() string {
+				if p.Foo == "" {
+					return "Foo"
+				}
+
+				return p.Foo
+			})(),
+		})
+		<p>{ bar }</p>
+		<p>{ baz.Foo }</p>
+	</div>
+}
+-- out --
+package main
+
+type Params struct {
+	Foo string
+}
+
+templ Child(p Params) {
+	<p>{ p.Foo }</p>
+}
+
+templ Parent(p Params) {
+	{{
+		bar := (func() string {
+			if p.Foo == "" {
+				return "Bar"
+			}
+
+			return p.Foo
+		})()
+		baz := Params{
+			Foo: (func() string {
+				if p.Foo == "" {
+					return "Baz"
+				}
+
+				return p.Foo
+			})(),
+		}
+	}}
+	<div>
+		@Child(Params{
+			Foo: (func() string {
+				if p.Foo == "" {
+					return "Foo"
+				}
+
+				return p.Foo
+			})(),
+		})
+		<p>{ bar }</p>
+		<p>{ baz.Foo }</p>
+	</div>
+}

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1210,6 +1210,10 @@ func (tee *TemplElementExpression) Write(w io.Writer, indent int) error {
 		if _, err := io.WriteString(w, "\n"); err != nil {
 			return err
 		}
+		// Blank lines should not have any indentation.
+		if len(bytes.TrimSpace(sourceLines[i])) == 0 {
+			continue
+		}
 		if string(sourceLines[i]) != string(reformattedSourceLines[i]) {
 			if _, err := w.Write(sourceLines[i]); err != nil {
 				return err


### PR DESCRIPTION
**Describe the bug**
`templ fmt` adds whitespace to blank lines when the line is:
- inside an inline func
- being used to set a struct value
- that is being passed as input to another templ component

**Root Cause**
The `TemplElementExpression.Write` method in `parser/v2/types.go` was formatting Go expressions by comparing the original formatted code with a re-indented version. When lines were identical in both versions (which blank lines always are), it would write them with indentation. This caused blank lines to incorrectly receive tab characters.

**The Fix**
Added a check before writing lines: if a line is blank (contains only whitespace when trimmed), skip indentation and continue to the next line. This ensures blank lines remain truly blank with no trailing whitespace.

**Changes**
- Modified `TemplElementExpression.Write` in `parser/v2/types.go` to check for blank lines
- Added comprehensive test case `inline_func_blank_lines_no_whitespace.txt` 

**Testing**
- All existing tests pass
- New test validates the fix for inline functions in three contexts:
  - Regular variable assignment
  - Struct field assignment  
  - As templ component arguments
- Manual testing confirms the formatter is now idempotent
- `templ fmt` can now be safely used in CI without introducing unwanted whitespace

Closes #1165