### PR TITLE
fix: LSP proxy SourceMapCache should not store nil SourceMaps

### DIFF
--- a/cmd/templ/lspcmd/proxy/sourcemapcache.go
+++ b/cmd/templ/lspcmd/proxy/sourcemapcache.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/a-h/templ/parser/v2"
@@ -54,5 +55,6 @@ func (fc *SourceMapCache) URIs() (uris []string) {
 		uris[i] = k
 		i++
 	}
+	slices.Sort(uris)
 	return uris
 }


### PR DESCRIPTION
Resolves: #1292

This attempts to fix the nil panic by preventing the `SourceMapCache` to store a nil `SourceMap`.

By deleting the cache entry for `uri` if the provided `SourceMap` is nil, we keep possibly expected behavior that writing a nil `SourceMap` "clears" the cache somewhat.

Adds basic unit test to check nil robustness of `Set`.