### PR TITLE
feat: add Range to Whitespace nodes

### DIFF
--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -1608,7 +1608,19 @@ func TestElementParser(t *testing.T) {
 					To:   Position{Index: 2, Line: 0, Col: 2},
 				},
 				Children: []Node{
-					&Whitespace{Value: " "},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 3,
+							Line:  0,
+							Col:   3,
+						},
+						To: Position{
+							Index: 4,
+							Line:  0,
+							Col:   4,
+						},
+					},
+						Value: " "},
 					&Element{
 						Name: "b",
 						NameRange: Range{
@@ -1617,7 +1629,19 @@ func TestElementParser(t *testing.T) {
 						},
 
 						Children: []Node{
-							&Whitespace{Value: " "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 7,
+									Line:  0,
+									Col:   7,
+								},
+								To: Position{
+									Index: 8,
+									Line:  0,
+									Col:   8,
+								},
+							},
+								Value: " "},
 						},
 						TrailingSpace: SpaceHorizontal,
 						Range: Range{

--- a/parser/v2/forexpressionparser_test.go
+++ b/parser/v2/forexpressionparser_test.go
@@ -35,7 +35,19 @@ func TestForExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 6,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 11,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&Text{
 						Range: Range{
 							From: Position{Index: 11, Line: 1, Col: 5},
@@ -73,7 +85,19 @@ func TestForExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 27,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 32,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&Text{
 						Range: Range{
 							From: Position{Index: 32, Line: 1, Col: 5},
@@ -111,7 +135,19 @@ func TestForExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 31,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 36,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&Text{
 						Range: Range{
 							From: Position{Index: 36, Line: 1, Col: 5},
@@ -149,7 +185,19 @@ func TestForExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 31,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 36,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&Element{
 						Name: "div",
 						NameRange: Range{
@@ -210,7 +258,19 @@ func TestForExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 30,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 35,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&Element{
 						Name: "div",
 						NameRange: Range{

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -46,7 +46,19 @@ func TestIfExpression(t *testing.T) {
 						},
 
 						Children: []Node{
-							&Whitespace{Value: "\n  "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 18,
+									Line:  1,
+									Col:   6,
+								},
+								To: Position{
+									Index: 21,
+									Line:  2,
+									Col:   2,
+								},
+							},
+								Value: "\n  "},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"span content"`,
@@ -104,7 +116,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 10,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&StringExpression{
 						Expression: Expression{
 							Value: `"A"`,
@@ -173,7 +197,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "  "},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 13,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 15,
+							Line:  1,
+							Col:   2,
+						},
+					},
+						Value: "  "},
 					&Text{
 						Value: "text",
 						Range: Range{
@@ -222,7 +258,19 @@ func TestIfExpression(t *testing.T) {
 						},
 
 						Children: []Node{
-							&Whitespace{Value: "\n  "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 18,
+									Line:  1,
+									Col:   6,
+								},
+								To: Position{
+									Index: 21,
+									Line:  2,
+									Col:   2,
+								},
+							},
+								Value: "\n  "},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"span content"`,
@@ -280,7 +328,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 8,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 9,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&StringExpression{
 						Expression: Expression{
 							Value: `"A"`,
@@ -350,7 +410,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 14,
+							Line:  1,
+							Col:   5,
+						},
+					},
+						Value: "\t\t\t\t\t"},
 					&IfExpression{
 						Expression: Expression{
 							Value: `p.B`,
@@ -368,7 +440,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t\t\t\t\t\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 23,
+									Line:  2,
+									Col:   0,
+								},
+								To: Position{
+									Index: 29,
+									Line:  2,
+									Col:   6,
+								},
+							},
+								Value: "\t\t\t\t\t\t"},
 							&Element{
 								Name: "div",
 								NameRange: Range{
@@ -407,7 +491,19 @@ func TestIfExpression(t *testing.T) {
 							To:   Position{Index: 54, Line: 3, Col: 6},
 						},
 					},
-					&Whitespace{Value: "\n\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 54,
+							Line:  3,
+							Col:   6,
+						},
+						To: Position{
+							Index: 59,
+							Line:  4,
+							Col:   4,
+						},
+					},
+						Value: "\n\t\t\t\t"},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
@@ -431,7 +527,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 10,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&StringExpression{
 						Expression: Expression{
 							Value: `"A"`,
@@ -453,7 +561,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 34,
+									Line:  3,
+									Col:   0,
+								},
+								To: Position{
+									Index: 35,
+									Line:  3,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"B"`,
@@ -495,7 +615,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 10,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&StringExpression{
 						Expression: Expression{
 							Value: `"A"`,
@@ -517,7 +649,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 34,
+									Line:  3,
+									Col:   0,
+								},
+								To: Position{
+									Index: 35,
+									Line:  3,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"B"`,
@@ -543,7 +687,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 59,
+									Line:  5,
+									Col:   0,
+								},
+								To: Position{
+									Index: 60,
+									Line:  5,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"C"`,
@@ -587,7 +743,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 10,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&StringExpression{
 						Expression: Expression{
 							Value: `"A"`,
@@ -609,7 +777,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 34,
+									Line:  3,
+									Col:   0,
+								},
+								To: Position{
+									Index: 35,
+									Line:  3,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"B"`,
@@ -635,7 +815,19 @@ func TestIfExpression(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 59,
+									Line:  5,
+									Col:   0,
+								},
+								To: Position{
+									Index: 60,
+									Line:  5,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"C"`,
@@ -695,7 +887,19 @@ func TestIfExpression(t *testing.T) {
 					},
 				},
 				Then: []Node{
-					&Whitespace{Value: "\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 9,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 11,
+							Line:  1,
+							Col:   2,
+						},
+					},
+						Value: "\t\t"},
 					&GoComment{
 						Contents:  " this is a comment",
 						Multiline: false,
@@ -704,7 +908,19 @@ func TestIfExpression(t *testing.T) {
 							To:   Position{Index: 31, Line: 1, Col: 22},
 						},
 					},
-					&Whitespace{Value: "\n\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 31,
+							Line:  1,
+							Col:   22,
+						},
+						To: Position{
+							Index: 33,
+							Line:  2,
+							Col:   1,
+						},
+					},
+						Value: "\n\t"},
 				},
 				Else: []Node{
 					&StringExpression{

--- a/parser/v2/switchexpressionparser_test.go
+++ b/parser/v2/switchexpressionparser_test.go
@@ -81,7 +81,19 @@ default:
 							},
 						},
 						Children: []Node{
-							&Whitespace{Value: "\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 28,
+									Line:  2,
+									Col:   0,
+								},
+								To: Position{
+									Index: 29,
+									Line:  2,
+									Col:   1,
+								},
+							},
+								Value: "\t"},
 							&Element{
 								Name: "span",
 								NameRange: Range{
@@ -89,7 +101,19 @@ default:
 									To:   Position{Index: 34, Line: 2, Col: 6},
 								},
 								Children: []Node{
-									&Whitespace{Value: "\n\t  "},
+									&Whitespace{Range: Range{
+										From: Position{
+											Index: 35,
+											Line:  2,
+											Col:   7,
+										},
+										To: Position{
+											Index: 39,
+											Line:  3,
+											Col:   3,
+										},
+									},
+										Value: "\n\t  "},
 									&StringExpression{
 										Expression: Expression{
 											Value: `"span content"`,
@@ -174,7 +198,19 @@ default:
 									To:   Position{Index: 41, Line: 2, Col: 5},
 								},
 								Children: []Node{
-									&Whitespace{Value: "\n  "},
+									&Whitespace{Range: Range{
+										From: Position{
+											Index: 42,
+											Line:  2,
+											Col:   6,
+										},
+										To: Position{
+											Index: 45,
+											Line:  3,
+											Col:   2,
+										},
+									},
+										Value: "\n  "},
 									&StringExpression{
 										Expression: Expression{
 											Value: `"span content"`,
@@ -253,6 +289,18 @@ default:
 						},
 						Children: []Node{
 							&Whitespace{
+								Range: Range{
+									From: Position{
+										Index: 30,
+										Line:  2,
+										Col:   0,
+									},
+									To: Position{
+										Index: 32,
+										Line:  2,
+										Col:   2,
+									},
+								},
 								Value: "\t\t",
 							},
 							&StringExpression{
@@ -293,6 +341,18 @@ default:
 						},
 						Children: []Node{
 							&Whitespace{
+								Range: Range{
+									From: Position{
+										Index: 51,
+										Line:  4,
+										Col:   0,
+									},
+									To: Position{
+										Index: 53,
+										Line:  4,
+										Col:   2,
+									},
+								},
 								Value: "\t\t",
 							},
 							&StringExpression{

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -302,7 +302,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 30, Line: 1, Col: 4},
 						},
 						Children: []Node{
-							&Whitespace{Value: "\n  "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 31,
+									Line:  1,
+									Col:   5,
+								},
+								To: Position{
+									Index: 34,
+									Line:  2,
+									Col:   2,
+								},
+							},
+								Value: "\n  "},
 							&StringExpression{
 								Expression: Expression{
 									Value: `"div content"`,
@@ -328,7 +340,19 @@ func TestTemplateParser(t *testing.T) {
 									To:   Position{Index: 59, Line: 3, Col: 7},
 								},
 								Children: []Node{
-									&Whitespace{Value: "\n\t"},
+									&Whitespace{Range: Range{
+										From: Position{
+											Index: 60,
+											Line:  3,
+											Col:   8,
+										},
+										To: Position{
+											Index: 62,
+											Line:  4,
+											Col:   1,
+										},
+									},
+										Value: "\n\t"},
 									&StringExpression{
 										Expression: Expression{
 											Value: `"span content"`,
@@ -396,7 +420,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 26,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 27,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&IfExpression{
 						Expression: Expression{
 							Value: `p.Test`,
@@ -414,7 +450,19 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						Then: []Node{
-							&Whitespace{Value: "\t\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 39,
+									Line:  2,
+									Col:   0,
+								},
+								To: Position{
+									Index: 41,
+									Line:  2,
+									Col:   2,
+								},
+							},
+								Value: "\t\t"},
 							&Element{
 								Name: "span",
 								NameRange: Range{
@@ -422,7 +470,19 @@ func TestTemplateParser(t *testing.T) {
 									To:   Position{Index: 46, Line: 2, Col: 7},
 								},
 								Children: []Node{
-									&Whitespace{"\n\t\t\t"},
+									&Whitespace{Range: Range{
+										From: Position{
+											Index: 47,
+											Line:  2,
+											Col:   8,
+										},
+										To: Position{
+											Index: 51,
+											Line:  3,
+											Col:   3,
+										},
+									},
+										Value: "\n\t\t\t"},
 									&StringExpression{
 										Expression: Expression{
 											Value: `"span content"`,
@@ -455,9 +515,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 82, Line: 5, Col: 2},
 						},
 					},
-					&Whitespace{
-						Value: "\n",
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 82,
+							Line:  5,
+							Col:   2,
+						},
+						To: Position{
+							Index: 83,
+							Line:  6,
+							Col:   0,
+						},
 					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -488,7 +558,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 26,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 27,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&Element{
 						Name: "input",
 						NameRange: Range{
@@ -589,7 +671,19 @@ func TestTemplateParser(t *testing.T) {
 					&DocType{
 						Value: "html",
 					},
-					&Whitespace{Value: "\n"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 30,
+							Line:  1,
+							Col:   15,
+						},
+						To: Position{
+							Index: 31,
+							Line:  2,
+							Col:   0,
+						},
+					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -629,9 +723,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{
-						Value: " ",
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 12,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   1,
+						},
 					},
+						Value: " "},
 					&Element{
 						Name: "a",
 						NameRange: Range{
@@ -651,7 +755,19 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						Children: []Node{
-							&Whitespace{Value: " "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 25,
+									Line:  1,
+									Col:   13,
+								},
+								To: Position{
+									Index: 26,
+									Line:  1,
+									Col:   14,
+								},
+							},
+								Value: " "},
 							&TemplElementExpression{
 								Expression: Expression{
 									Value: `Icon("home", Inline)`,
@@ -673,7 +789,19 @@ func TestTemplateParser(t *testing.T) {
 									To:   Position{Index: 47, Line: 1, Col: 35},
 								},
 							},
-							&Whitespace{Value: " "},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 47,
+									Line:  1,
+									Col:   35,
+								},
+								To: Position{
+									Index: 48,
+									Line:  1,
+									Col:   36,
+								},
+							},
+								Value: " "},
 							&Text{
 								Value: "Home",
 								Range: Range{
@@ -709,7 +837,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 12,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&GoComment{
 						Contents:  " Comment",
 						Multiline: false,
@@ -718,7 +858,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 23, Line: 1, Col: 11},
 						},
 					},
-					&Whitespace{Value: "\n"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 23,
+							Line:  1,
+							Col:   11,
+						},
+						To: Position{
+							Index: 24,
+							Line:  2,
+							Col:   0,
+						},
+					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -740,7 +892,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 12,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&GoComment{
 						Contents:  " Comment ",
 						Multiline: true,
@@ -749,7 +913,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 26, Line: 1, Col: 14},
 						},
 					},
-					&Whitespace{Value: "\n"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 26,
+							Line:  1,
+							Col:   14,
+						},
+						To: Position{
+							Index: 27,
+							Line:  2,
+							Col:   0,
+						},
+					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -773,7 +949,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 12,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&GoComment{
 						Contents:  " Line 1\n\t\t Line 2\n\t",
 						Multiline: true,
@@ -782,7 +970,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 36, Line: 3, Col: 3},
 						},
 					},
-					&Whitespace{Value: "\n"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 36,
+							Line:  3,
+							Col:   3,
+						},
+						To: Position{
+							Index: 37,
+							Line:  4,
+							Col:   0,
+						},
+					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -807,7 +1007,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 12,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 13,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&HTMLComment{
 						Contents: " Single line ",
 						Range: Range{
@@ -815,7 +1027,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 33, Line: 1, Col: 21},
 						},
 					},
-					&Whitespace{Value: "\n\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 33,
+							Line:  1,
+							Col:   21,
+						},
+						To: Position{
+							Index: 35,
+							Line:  2,
+							Col:   1,
+						},
+					},
+						Value: "\n\t"},
 					&HTMLComment{
 						Contents: "\n\t\tMultiline\n\t",
 						Range: Range{
@@ -823,7 +1047,19 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 56, Line: 4, Col: 4},
 						},
 					},
-					&Whitespace{Value: "\n"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 56,
+							Line:  4,
+							Col:   4,
+						},
+						To: Position{
+							Index: 57,
+							Line:  5,
+							Col:   0,
+						},
+					},
+						Value: "\n"},
 				},
 			},
 		},
@@ -855,7 +1091,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 40,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 42,
+							Line:  1,
+							Col:   2,
+						},
+					},
+						Value: "\t\t"},
 					&Element{
 						Name: "span",
 						NameRange: Range{
@@ -880,9 +1128,33 @@ func TestTemplateParser(t *testing.T) {
 							},
 						}},
 						Children: []Node{
-							&Whitespace{"\n\t\t\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 64,
+									Line:  1,
+									Col:   24,
+								},
+								To: Position{
+									Index: 68,
+									Line:  2,
+									Col:   3,
+								},
+							},
+								Value: "\n\t\t\t"},
 							&ChildrenExpression{},
-							&Whitespace{Value: "\n\t\t"},
+							&Whitespace{Range: Range{
+								From: Position{
+									Index: 83,
+									Line:  2,
+									Col:   18,
+								},
+								To: Position{
+									Index: 86,
+									Line:  3,
+									Col:   2,
+								},
+							},
+								Value: "\n\t\t"},
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
@@ -912,7 +1184,19 @@ func TestTemplateParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 15,
+							Line:  1,
+							Col:   0,
+						},
+						To: Position{
+							Index: 16,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\t"},
 					&Element{
 						Name: "br",
 						NameRange: Range{

--- a/parser/v2/templelementparser_test.go
+++ b/parser/v2/templelementparser_test.go
@@ -116,7 +116,19 @@ func TestTemplElementExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\n\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 16,
+							Line:  0,
+							Col:   16,
+						},
+						To: Position{
+							Index: 18,
+							Line:  1,
+							Col:   1,
+						},
+					},
+						Value: "\n\t"},
 					&Text{
 						Value: "some words",
 						Range: Range{
@@ -154,7 +166,19 @@ func TestTemplElementExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\n\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 15,
+							Line:  0,
+							Col:   15,
+						},
+						To: Position{
+							Index: 19,
+							Line:  1,
+							Col:   3,
+						},
+					},
+						Value: "\n\t\t\t"},
 					&Element{
 						Name: "a",
 						NameRange: Range{
@@ -208,7 +232,19 @@ func TestTemplElementExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\n\t\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 16,
+							Line:  0,
+							Col:   16,
+						},
+						To: Position{
+							Index: 21,
+							Line:  1,
+							Col:   4,
+						},
+					},
+						Value: "\n\t\t\t\t"},
 					&TemplElementExpression{
 						Expression: Expression{
 							Value: "other2",
@@ -222,7 +258,19 @@ func TestTemplElementExpressionParser(t *testing.T) {
 							To:   Position{Index: 28, Line: 1, Col: 11},
 						},
 					},
-					&Whitespace{Value: "\n\t\t\t"},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 28,
+							Line:  1,
+							Col:   11,
+						},
+						To: Position{
+							Index: 32,
+							Line:  2,
+							Col:   3,
+						},
+					},
+						Value: "\n\t\t\t"},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
@@ -462,7 +510,19 @@ func TestTemplElementExpressionParser(t *testing.T) {
 					},
 				},
 				Children: []Node{
-					&Whitespace{Value: "\n  "},
+					&Whitespace{Range: Range{
+						From: Position{
+							Index: 35,
+							Line:  0,
+							Col:   35,
+						},
+						To: Position{
+							Index: 38,
+							Line:  1,
+							Col:   2,
+						},
+					},
+						Value: "\n  "},
 					&Element{
 						Name: "div",
 						NameRange: Range{

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -233,6 +233,7 @@ func (p *Package) Visit(v Visitor) error {
 
 // Whitespace.
 type Whitespace struct {
+	Range Range
 	Value string
 }
 

--- a/parser/v2/whitespaceparser.go
+++ b/parser/v2/whitespaceparser.go
@@ -5,8 +5,10 @@ import "github.com/a-h/parse"
 // Eat any whitespace.
 var whitespaceExpression = parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
 	r := &Whitespace{}
+	start := pi.Position()
 	if r.Value, ok, err = parse.OptionalWhitespace.Parse(pi); err != nil || !ok {
 		return
 	}
+	r.Range = NewRange(start, pi.Position())
 	return r, len(r.Value) > 0, nil
 })


### PR DESCRIPTION
Adds a `Range` to the parser's `Whitespace` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.