### PR TITLE
feat: add Range to DocType nodes

### DIFF
--- a/parser/v2/doctypeparser.go
+++ b/parser/v2/doctypeparser.go
@@ -27,6 +27,7 @@ var docType = parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
 		err = parse.Error("unclosed DOCTYPE", start)
 		return
 	}
+	r.Range = NewRange(start, pi.Position())
 
 	return r, true, nil
 })

--- a/parser/v2/doctypeparser_test.go
+++ b/parser/v2/doctypeparser_test.go
@@ -17,6 +17,10 @@ func TestDocTypeParser(t *testing.T) {
 			name:  "HTML 5 doctype - uppercase",
 			input: `<!DOCTYPE html>`,
 			expected: &DocType{
+				Range: Range{
+					From: Position{},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
 				Value: "html",
 			},
 		},
@@ -24,6 +28,10 @@ func TestDocTypeParser(t *testing.T) {
 			name:  "HTML 5 doctype - lowercase",
 			input: `<!doctype html>`,
 			expected: &DocType{
+				Range: Range{
+					From: Position{},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
 				Value: "html",
 			},
 		},
@@ -31,6 +39,10 @@ func TestDocTypeParser(t *testing.T) {
 			name:  "HTML 4.01 doctype",
 			input: `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">`,
 			expected: &DocType{
+				Range: Range{
+					From: Position{},
+					To:   Position{Index: 102, Line: 0, Col: 102},
+				},
 				Value: `HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"`,
 			},
 		},
@@ -38,6 +50,10 @@ func TestDocTypeParser(t *testing.T) {
 			name:  "XHTML 1.1",
 			input: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">`,
 			expected: &DocType{
+				Range: Range{
+					From: Position{},
+					To:   Position{Index: 97, Line: 0, Col: 97},
+				},
 				Value: `html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"`,
 			},
 		},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -587,6 +587,10 @@ func TestTemplateParser(t *testing.T) {
 				},
 				Children: []Node{
 					&DocType{
+						Range: Range{
+							From: Position{Index: 15, Line: 1, Col: 0},
+							To:   Position{Index: 30, Line: 1, Col: 15},
+						},
 						Value: "html",
 					},
 					&Whitespace{Value: "\n"},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -363,6 +363,7 @@ func (c *ExpressionCSSProperty) Visit(v Visitor) error {
 
 // <!DOCTYPE html>
 type DocType struct {
+	Range Range
 	Value string
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `DocType` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301.