### PR TITLE
fix: normalize leading whitespaces in multiline go code

### DIFF
--- a/parser/v2/expressionparser.go
+++ b/parser/v2/expressionparser.go
@@ -29,7 +29,7 @@ func ExpressionOf(p parse.Parser[string]) parse.Parser[Expression] {
 var lt = parse.Rune('<')
 var gt = parse.Rune('>')
 var spaceOrTab = parse.Any(parse.Rune(' '), parse.Rune('\t'))
-var spaceOrTabOrNewLine = parse.Any(spaceOrTab, parse.Rune('\n'))
+var spaceOrTabOrNewLine = parse.Any(spaceOrTab, parse.String("\r\n"), parse.Rune('\n'))
 var openBrace = parse.String("{")
 var optionalSpaces = parse.StringFrom(parse.Optional(
 	parse.AtLeast(1, spaceOrTab)))


### PR DESCRIPTION
I had an issue where templ fmt would add an extra newline and leading tabs in the beginning of every multiline go code expression in templates. My case looked like this:

```
 templ treeViewItem(item TreeViewItem, depth int) {
	<details>
		{{
			rawUrl := ""
			if depth == 1 {
				rawUrl = fmt.Sprintf("/system/%d", item.id)
			} else if depth == 2 {
				rawUrl = fmt.Sprintf("/central/%d", item.id)
			} else if depth == 3 {
				rawUrl = fmt.Sprintf("/department/%d", item.id)
			}
		}}
        ...
```
which got formatted to:
```
 templ treeViewItem(item TreeViewItem, depth int) {
	<details>
		{{
                       
			rawUrl := ""
			if depth == 1 {
				rawUrl = fmt.Sprintf("/system/%d", item.id)
			} else if depth == 2 {
				rawUrl = fmt.Sprintf("/central/%d", item.id)
			} else if depth == 3 {
				rawUrl = fmt.Sprintf("/department/%d", item.id)
			}
		}}
        ...
```
Every time the formatter ran a new newline would appear above ' rawUrl := "" '

I noticed that the Go Code Writer always adds a number of tabs depending on the indentation and then a newline ahead of the go code so I fixed the issue by trimming any leading \r \n and \t characters before writing the node, thus normalizing the string so it always starts with exactly one newline and the correct number of tabs.