### PR TITLE
fix: proxy escaping characters

### DIFF
--- a/cmd/templ/generatecmd/proxy/proxy.go
+++ b/cmd/templ/generatecmd/proxy/proxy.go
@@ -111,8 +111,7 @@ func streamInsertAfterBodyOpen(nonce string, r io.Reader, w io.Writer) error {
 				}
 			}
 		default:
-			t := z.Token()
-			_, err := w.Write([]byte(t.String()))
+			_, err := w.Write(z.Raw())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The bug was introduced in #1271. `Token`'s `String` method(https://cs.opensource.google/go/x/net/+/master:html/token.go;l=105) escapes tag body text, which shouldn't happen. `String` method is replaced by `Raw` which makes sense imo because the html is already produced by templ, there's no need to format/process it again.

fixes #1316