### PR TITLE
feat: add Range to SpreadAttributes nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -337,6 +337,7 @@ var spreadAttributesParser = parse.Func(func(pi *parse.Input) (attr *SpreadAttri
 		return
 	}
 
+	attrStart := pi.Index()
 	// Eat the first brace.
 	if _, ok, err = openBraceWithOptionalPadding.Parse(pi); err != nil ||
 		!ok {
@@ -367,6 +368,7 @@ var spreadAttributesParser = parse.Func(func(pi *parse.Input) (attr *SpreadAttri
 		err = parse.Error("attribute spread expression: missing closing brace", pi.Position())
 		return
 	}
+	attr.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 	return attr, true, nil
 })

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -365,7 +365,7 @@ if test {` + " " + `
 			input:  ` { spread... }"`,
 			parser: StripType(spreadAttributesParser),
 			expected: &SpreadAttributes{
-				Expression{
+				Expression: Expression{
 					Value: "spread",
 					Range: Range{
 						From: Position{
@@ -379,6 +379,10 @@ if test {` + " " + `
 							Col:   9,
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 14, Line: 0, Col: 14},
 				},
 			},
 		},
@@ -1035,6 +1039,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 21, Line: 0, Col: 21},
+						},
 					},
 					&SpreadAttributes{
 						Expression: Expression{
@@ -1051,6 +1059,10 @@ func TestElementParser(t *testing.T) {
 									Col:   32,
 								},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 22, Line: 0, Col: 22},
+							To:   Position{Index: 37, Line: 0, Col: 37},
 						},
 					},
 				},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -1115,7 +1115,7 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 47, Line: 1, Col: 7},
 						},
 						Attributes: []Attribute{&SpreadAttributes{
-							Expression{
+							Expression: Expression{
 								Value: "children",
 								Range: Range{
 									From: Position{
@@ -1129,6 +1129,10 @@ func TestTemplateParser(t *testing.T) {
 										Col:   18,
 									},
 								},
+							},
+							Range: Range{
+								From: Position{Index: 48, Line: 1, Col: 8},
+								To:   Position{Index: 63, Line: 1, Col: 23},
 							},
 						}},
 						Children: []Node{

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1012,6 +1012,7 @@ func (ea *ExpressionAttribute) Copy() Attribute {
 // <a { spread... } />
 type SpreadAttributes struct {
 	Expression Expression
+	Range      Range
 }
 
 func (sa *SpreadAttributes) String() string {
@@ -1029,6 +1030,7 @@ func (sa *SpreadAttributes) Visit(v Visitor) error {
 func (sa *SpreadAttributes) Copy() Attribute {
 	return &SpreadAttributes{
 		Expression: sa.Expression,
+		Range:      sa.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `SpreadAttributes` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301 and #1302.