### PR TITLE
feat: add Range to BooleanExpressionAttribute nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -259,6 +259,7 @@ var boolExpressionAttributeParser = parse.Func(func(pi *parse.Input) (r *BoolExp
 		return
 	}
 
+	attrStart := pi.Index()
 	r = &BoolExpressionAttribute{}
 
 	// Attribute name.
@@ -284,6 +285,7 @@ var boolExpressionAttributeParser = parse.Func(func(pi *parse.Input) (r *BoolExp
 		pi.Seek(start)
 		return
 	}
+	r.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 	return r, true, nil
 })

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -271,6 +271,10 @@ if test {` + " " + `
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 18, Line: 0, Col: 18},
+				},
 			},
 		},
 		{
@@ -299,6 +303,10 @@ if test {` + " " + `
 							Col:   15,
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 16, Line: 0, Col: 16},
 				},
 			},
 		},
@@ -329,6 +337,10 @@ if test {` + " " + `
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 18, Line: 0, Col: 18},
+				},
 			},
 		},
 		{
@@ -357,6 +369,10 @@ if test {` + " " + `
 							Col:   16,
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 20, Line: 0, Col: 20},
 				},
 			},
 		},
@@ -866,6 +882,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 21, Line: 0, Col: 21},
+						},
 					},
 				},
 				Range: Range{
@@ -1101,6 +1121,10 @@ func TestElementParser(t *testing.T) {
 									Col:   27,
 								},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 12, Line: 0, Col: 12},
+							To:   Position{Index: 29, Line: 0, Col: 29},
 						},
 					},
 					&ConstantAttribute{

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -919,6 +919,7 @@ func (ca *ConstantAttribute) Copy() Attribute {
 type BoolExpressionAttribute struct {
 	Key        AttributeKey
 	Expression Expression
+	Range      Range
 }
 
 func (bea *BoolExpressionAttribute) String() string {
@@ -937,6 +938,7 @@ func (bea *BoolExpressionAttribute) Copy() Attribute {
 	return &BoolExpressionAttribute{
 		Expression: bea.Expression,
 		Key:        bea.Key,
+		Range:      bea.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `BooleanExpressionAttribute` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302, and #1335.