### PR TITLE
feat: add Range to ChildrenExpression nodes

### DIFF
--- a/parser/v2/childrenparser.go
+++ b/parser/v2/childrenparser.go
@@ -13,9 +13,12 @@ var childrenExpressionParser = parse.StringFrom(
 )
 
 var childrenExpression = parse.Func(func(in *parse.Input) (n Node, ok bool, err error) {
+	r := &ChildrenExpression{}
+	start := in.Position()
 	_, ok, err = childrenExpressionParser.Parse(in)
 	if err != nil || !ok {
 		return
 	}
-	return &ChildrenExpression{}, true, nil
+	r.Range = NewRange(start, in.Position())
+	return r, true, nil
 })

--- a/parser/v2/childrenparser.go
+++ b/parser/v2/childrenparser.go
@@ -13,12 +13,13 @@ var childrenExpressionParser = parse.StringFrom(
 )
 
 var childrenExpression = parse.Func(func(in *parse.Input) (n Node, ok bool, err error) {
-	r := &ChildrenExpression{}
 	start := in.Position()
 	_, ok, err = childrenExpressionParser.Parse(in)
 	if err != nil || !ok {
 		return
 	}
-	r.Range = NewRange(start, in.Position())
+	r := &ChildrenExpression{
+		Range: NewRange(start, in.Position()),
+	}
 	return r, true, nil
 })

--- a/parser/v2/childrenparser_test.go
+++ b/parser/v2/childrenparser_test.go
@@ -14,19 +14,34 @@ func TestChildrenExpressionParser(t *testing.T) {
 		expected *ChildrenExpression
 	}{
 		{
-			name:     "standard",
-			input:    `{ children...}`,
-			expected: &ChildrenExpression{},
+			name:  "standard",
+			input: `{ children...}`,
+			expected: &ChildrenExpression{
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 14, Line: 0, Col: 14},
+				},
+			},
 		},
 		{
-			name:     "condensed",
-			input:    `{children...}`,
-			expected: &ChildrenExpression{},
+			name:  "condensed",
+			input: `{children...}`,
+			expected: &ChildrenExpression{
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 13, Line: 0, Col: 13},
+				},
+			},
 		},
 		{
-			name:     "extra spaces",
-			input:    `{  children...  }`,
-			expected: &ChildrenExpression{},
+			name:  "extra spaces",
+			input: `{  children...  }`,
+			expected: &ChildrenExpression{
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 17, Line: 0, Col: 17},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -48,7 +63,7 @@ func TestChildrenExpressionParser(t *testing.T) {
 }
 
 func TestChildrenExpressionParserAllocsOK(t *testing.T) {
-	RunParserAllocTest(t, childrenExpression, true, 2, `{ children... }`)
+	RunParserAllocTest(t, childrenExpression, true, 3, `{ children... }`)
 }
 
 func TestChildrenExpressionParserAllocsSkip(t *testing.T) {

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -1149,7 +1149,12 @@ func TestTemplateParser(t *testing.T) {
 								},
 							},
 								Value: "\n\t\t\t"},
-							&ChildrenExpression{},
+							&ChildrenExpression{
+								Range: Range{
+									From: Position{Index: 68, Line: 2, Col: 3},
+									To:   Position{Index: 83, Line: 2, Col: 18},
+								},
+							},
 							&Whitespace{Range: Range{
 								From: Position{
 									Index: 83,

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1264,7 +1264,7 @@ func (tee *TemplElementExpression) Visit(v Visitor) error {
 	return v.VisitTemplElementExpression(tee)
 }
 
-// ChildrenExpression can be used to rended the children of a templ element.
+// ChildrenExpression can be used to render the children of a templ element.
 // { children ... }
 type ChildrenExpression struct {
 	Range Range

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1266,10 +1266,12 @@ func (tee *TemplElementExpression) Visit(v Visitor) error {
 
 // ChildrenExpression can be used to rended the children of a templ element.
 // { children ... }
-type ChildrenExpression struct{}
+type ChildrenExpression struct {
+	Range Range
+}
 
 func (*ChildrenExpression) IsNode() bool { return true }
-func (*ChildrenExpression) Write(w io.Writer, indent int) error {
+func (ce *ChildrenExpression) Write(w io.Writer, indent int) error {
 	if err := writeIndent(w, indent, "{ children... }"); err != nil {
 		return err
 	}

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1271,7 +1271,7 @@ type ChildrenExpression struct {
 }
 
 func (*ChildrenExpression) IsNode() bool { return true }
-func (ce *ChildrenExpression) Write(w io.Writer, indent int) error {
+func (*ChildrenExpression) Write(w io.Writer, indent int) error {
 	if err := writeIndent(w, indent, "{ children... }"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a `Range` to the parser's `ChildrenExpression` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, and #1336.