### PR TITLE
feat: add Range to ConditionalAttribute nodes

### DIFF
--- a/parser/v2/conditionalattributeparser.go
+++ b/parser/v2/conditionalattributeparser.go
@@ -16,6 +16,7 @@ func (conditionalAttributeParser) Parse(pi *parse.Input) (r *ConditionalAttribut
 	if _, _, err = parse.OptionalWhitespace.Parse(pi); err != nil {
 		return
 	}
+	attrStart := pi.Index()
 	if !peekPrefix(pi, "if ") {
 		pi.Seek(start)
 		return
@@ -65,6 +66,7 @@ func (conditionalAttributeParser) Parse(pi *parse.Input) (r *ConditionalAttribut
 		err = parse.Error("attribute if: missing end (expected '}')", pi.Position())
 		return
 	}
+	r.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 	return r, true, nil
 }

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -169,6 +169,10 @@ func TestAttributeParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 3, Line: 1, Col: 2},
+					To:   Position{Index: 44, Line: 3, Col: 3},
+				},
 			},
 		},
 		{
@@ -241,6 +245,10 @@ if test {` + " " + `
 							},
 						},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 1, Col: 0},
+					To:   Position{Index: 58, Line: 5, Col: 1},
 				},
 			},
 		},
@@ -1236,6 +1244,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 27, Line: 1, Col: 2},
+							To:   Position{Index: 68, Line: 3, Col: 3},
+						},
 					},
 				},
 				IndentAttrs: true,
@@ -1349,6 +1361,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 30, Line: 1, Col: 3},
+							To:   Position{Index: 65, Line: 3, Col: 4},
+						},
 					},
 				},
 				IndentAttrs: true,
@@ -1424,6 +1440,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 30, Line: 1, Col: 3},
+							To:   Position{Index: 101, Line: 5, Col: 4},
+						},
 					},
 				},
 				IndentAttrs: true,
@@ -1484,6 +1504,10 @@ func TestElementParser(t *testing.T) {
 									},
 								},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 29, Line: 1, Col: 3},
+							To:   Position{Index: 64, Line: 3, Col: 4},
 						},
 					},
 				},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1040,6 +1040,7 @@ type ConditionalAttribute struct {
 	Expression Expression
 	Then       []Attribute
 	Else       []Attribute
+	Range      Range
 }
 
 func (ca *ConditionalAttribute) String() string {
@@ -1107,6 +1108,7 @@ func (ca *ConditionalAttribute) Copy() Attribute {
 		Expression: ca.Expression,
 		Then:       CopyAttributes(ca.Then),
 		Else:       CopyAttributes(ca.Else),
+		Range:      ca.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `ConditionalAttribute` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, #1336, and #1337.