### PR TITLE
feat: add Range to BoolConstantAttribute nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -220,6 +220,7 @@ var boolConstantAttributeParser = parse.Func(func(pi *parse.Input) (attr *BoolCo
 		return
 	}
 
+	attrStart := pi.Index()
 	attr = &BoolConstantAttribute{}
 
 	// Attribute name.
@@ -243,6 +244,7 @@ var boolConstantAttributeParser = parse.Func(func(pi *parse.Input) (attr *BoolCo
 		err = parse.Error(fmt.Sprintf("boolConstantAttributeParser: expected attribute name to end with space, newline, '/>' or '>', but got %q", next), pi.Position())
 		return attr, false, err
 	}
+	attr.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 	return attr, true, nil
 })

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -220,6 +220,10 @@ if test {` + " " + `
 								To:   Position{Index: 38, Line: 3, Col: 8},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 31, Line: 3, Col: 1},
+							To:   Position{Index: 38, Line: 3, Col: 8},
+						},
 					},
 					&ExpressionAttribute{
 						Key: ConstantAttributeKey{
@@ -525,6 +529,10 @@ if test {` + " " + `
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 9, Line: 0, Col: 9},
+						},
 					},
 				},
 			},
@@ -558,6 +566,10 @@ if test {` + " " + `
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 14, Line: 0, Col: 14},
+						},
 					},
 				},
 			},
@@ -581,6 +593,10 @@ if test {` + " " + `
 								From: Position{Index: 9, Line: 1, Col: 2},
 								To:   Position{Index: 17, Line: 1, Col: 10},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 9, Line: 1, Col: 2},
+							To:   Position{Index: 17, Line: 1, Col: 10},
 						},
 					},
 				},
@@ -609,6 +625,10 @@ if test {` + " " + `
 								From: Position{Index: 10, Line: 1, Col: 2},
 								To:   Position{Index: 18, Line: 1, Col: 10},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 10, Line: 1, Col: 2},
+							To:   Position{Index: 18, Line: 1, Col: 10},
 						},
 					},
 				},
@@ -833,6 +853,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 4, Line: 0, Col: 4},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 11, Line: 0, Col: 11},
 						},
 					},
 				},
@@ -1117,6 +1141,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 4, Line: 0, Col: 4},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 11, Line: 0, Col: 11},
 						},
 					},
 					&BoolExpressionAttribute{
@@ -2014,6 +2042,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 20, Line: 0, Col: 20},
 								To:   Position{Index: 28, Line: 0, Col: 28},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 20, Line: 0, Col: 20},
+							To:   Position{Index: 28, Line: 0, Col: 28},
 						},
 					},
 					&ExpressionAttribute{

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -863,7 +863,8 @@ func (e ExpressionAttributeKey) String() string {
 
 // <hr noshade/>
 type BoolConstantAttribute struct {
-	Key AttributeKey
+	Key   AttributeKey
+	Range Range
 }
 
 func (bca *BoolConstantAttribute) String() string {
@@ -880,7 +881,8 @@ func (bca *BoolConstantAttribute) Visit(v Visitor) error {
 
 func (bca *BoolConstantAttribute) Copy() Attribute {
 	return &BoolConstantAttribute{
-		Key: bca.Key,
+		Key:   bca.Key,
+		Range: bca.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `BoolConstantAttribute` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, #1336, #1337, and #1338.