### PR TITLE
feat: add Range to ConstantAttribute nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -139,6 +139,7 @@ var (
 			return
 		}
 
+		attrStart := pi.Index()
 		attr = &ConstantAttribute{}
 
 		// Attribute name.
@@ -169,6 +170,7 @@ var (
 
 		// Only use single quotes if actually required, due to double quote in the value (prefer double quotes).
 		attr.SingleQuote = attr.SingleQuote && strings.Contains(attr.Value, "\"")
+		attr.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 		return attr, true, nil
 	})

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -61,6 +61,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 6, Line: 0, Col: 6},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 20, Line: 0, Col: 20},
+						},
 					},
 				},
 			},
@@ -85,6 +89,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 25, Line: 0, Col: 25},
+						},
 					},
 					&ConstantAttribute{
 						Value: "{'foo': true}",
@@ -94,6 +102,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 26, Line: 0, Col: 26},
 								To:   Position{Index: 32, Line: 0, Col: 32},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 26, Line: 0, Col: 26},
+							To:   Position{Index: 48, Line: 0, Col: 48},
 						},
 					},
 				},
@@ -119,6 +131,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 13, Line: 0, Col: 13},
+						},
 					},
 					&ConstantAttribute{
 						Value: "padding: 10px",
@@ -128,6 +144,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 14, Line: 0, Col: 14},
 								To:   Position{Index: 19, Line: 0, Col: 19},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 14, Line: 0, Col: 14},
+							To:   Position{Index: 35, Line: 0, Col: 35},
 						},
 					},
 				},
@@ -166,6 +186,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 23, Line: 2, Col: 3},
 								To:   Position{Index: 28, Line: 2, Col: 8},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 23, Line: 2, Col: 3},
+							To:   Position{Index: 40, Line: 2, Col: 20},
 						},
 					},
 				},
@@ -210,6 +234,10 @@ if test {` + " " + `
 								From: Position{Index: 13, Line: 2, Col: 1},
 								To:   Position{Index: 18, Line: 2, Col: 6},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 13, Line: 2, Col: 1},
+							To:   Position{Index: 29, Line: 2, Col: 17},
 						},
 					},
 					&BoolConstantAttribute{
@@ -423,6 +451,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 12, Line: 0, Col: 12},
+				},
 			},
 		},
 		{
@@ -438,6 +470,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 32, Line: 0, Col: 32},
 				},
 			},
 		},
@@ -455,6 +491,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 14, Line: 0, Col: 14},
+				},
 			},
 		},
 		{
@@ -470,6 +510,10 @@ if test {` + " " + `
 						To:   Position{Index: 21, Line: 0, Col: 21},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 29, Line: 0, Col: 29},
+				},
 			},
 		},
 		{
@@ -484,6 +528,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 8, Line: 0, Col: 8},
 				},
 			},
 		},
@@ -502,6 +550,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 12, Line: 0, Col: 12},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 69, Line: 2, Col: 17},
 				},
 			},
 		},
@@ -632,6 +684,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
 			},
 		},
 		{
@@ -646,6 +702,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 13, Line: 0, Col: 13},
 				},
 			},
 		},
@@ -662,6 +722,10 @@ if test {` + " " + `
 						To:   Position{Index: 12, Line: 0, Col: 12},
 					},
 				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 22, Line: 0, Col: 22},
+				},
 			},
 		},
 		{
@@ -676,6 +740,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				Range: Range{
+					From: Position{Index: 1, Line: 0, Col: 1},
+					To:   Position{Index: 9, Line: 0, Col: 9},
 				},
 			},
 		},
@@ -736,6 +804,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 3, Line: 0, Col: 3},
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 14, Line: 0, Col: 14},
 						},
 					},
 				},
@@ -1023,6 +1095,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 14, Line: 0, Col: 14},
+						},
 					},
 					&ConstantAttribute{
 						Value: "text-underline: auto",
@@ -1032,6 +1108,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 15, Line: 0, Col: 15},
 								To:   Position{Index: 20, Line: 0, Col: 20},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 15, Line: 0, Col: 15},
+							To:   Position{Index: 43, Line: 0, Col: 43},
 						},
 					},
 				},
@@ -1156,6 +1236,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 37, Line: 0, Col: 37},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 30, Line: 0, Col: 30},
+							To:   Position{Index: 45, Line: 0, Col: 45},
+						},
 					},
 				},
 				Range: Range{
@@ -1182,6 +1266,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 3, Line: 0, Col: 3},
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 14, Line: 0, Col: 14},
 						},
 					},
 					&ExpressionAttribute{
@@ -1217,6 +1305,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 58, Line: 0, Col: 58},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 53, Line: 0, Col: 53},
+							To:   Position{Index: 81, Line: 0, Col: 81},
+						},
 					},
 				},
 				Range: Range{
@@ -1251,6 +1343,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 10, Line: 0, Col: 10},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 					},
 					&ConditionalAttribute{
 						Expression: Expression{
@@ -1277,6 +1373,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 47, Line: 2, Col: 3},
 										To:   Position{Index: 52, Line: 2, Col: 8},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 47, Line: 2, Col: 3},
+									To:   Position{Index: 64, Line: 2, Col: 20},
 								},
 							},
 						},
@@ -1337,6 +1437,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 25, Line: 0, Col: 25},
+						},
 					},
 				},
 				Range: Range{
@@ -1368,6 +1472,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 25, Line: 0, Col: 25},
+						},
 					},
 					&ConditionalAttribute{
 						Expression: Expression{
@@ -1394,6 +1502,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 44, Line: 2, Col: 4},
 										To:   Position{Index: 49, Line: 2, Col: 9},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 44, Line: 2, Col: 4},
+									To:   Position{Index: 60, Line: 2, Col: 20},
 								},
 							},
 						},
@@ -1435,6 +1547,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 25, Line: 0, Col: 25},
+						},
 					},
 					&ConditionalAttribute{
 						Expression: Expression{
@@ -1462,6 +1578,10 @@ func TestElementParser(t *testing.T) {
 										To:   Position{Index: 49, Line: 2, Col: 9},
 									},
 								},
+								Range: Range{
+									From: Position{Index: 44, Line: 2, Col: 4},
+									To:   Position{Index: 60, Line: 2, Col: 20},
+								},
 							},
 						},
 						Else: []Attribute{
@@ -1473,6 +1593,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 77, Line: 4, Col: 4},
 										To:   Position{Index: 82, Line: 4, Col: 9},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 77, Line: 4, Col: 4},
+									To:   Position{Index: 96, Line: 4, Col: 23},
 								},
 							},
 						},
@@ -1512,6 +1636,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 8, Line: 0, Col: 8},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 					},
 					&ConditionalAttribute{
 						Expression: Expression{
@@ -1538,6 +1666,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 43, Line: 2, Col: 4},
 										To:   Position{Index: 48, Line: 2, Col: 9},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 43, Line: 2, Col: 4},
+									To:   Position{Index: 59, Line: 2, Col: 20},
 								},
 							},
 						},
@@ -1836,6 +1968,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 0, Col: 12},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 8, Line: 0, Col: 8},
+							To:   Position{Index: 20, Line: 0, Col: 20},
+						},
 					},
 					&ConstantAttribute{
 						Value: "email",
@@ -1846,6 +1982,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 23, Line: 0, Col: 23},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 21, Line: 0, Col: 21},
+							To:   Position{Index: 31, Line: 0, Col: 31},
+						},
 					},
 					&ConstantAttribute{
 						Value: "email",
@@ -1855,6 +1995,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 32, Line: 0, Col: 32},
 								To:   Position{Index: 36, Line: 0, Col: 36},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 32, Line: 0, Col: 32},
+							To:   Position{Index: 44, Line: 0, Col: 44},
 						},
 					},
 					&ExpressionAttribute{
@@ -1890,6 +2034,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 102, Line: 0, Col: 102},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 91, Line: 0, Col: 91},
+							To:   Position{Index: 119, Line: 0, Col: 119},
+						},
 					},
 					&ConstantAttribute{
 						Value: "off",
@@ -1899,6 +2047,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 120, Line: 0, Col: 120},
 								To:   Position{Index: 132, Line: 0, Col: 132},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 120, Line: 0, Col: 120},
+							To:   Position{Index: 138, Line: 0, Col: 138},
 						},
 					},
 				},
@@ -1932,6 +2084,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 1, Col: 5},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 8, Line: 1, Col: 1},
+							To:   Position{Index: 20, Line: 1, Col: 13},
+						},
 					},
 					&ConstantAttribute{
 						Value: "email",
@@ -1942,6 +2098,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 25, Line: 2, Col: 3},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 23, Line: 2, Col: 1},
+							To:   Position{Index: 33, Line: 2, Col: 11},
+						},
 					},
 					&ConstantAttribute{
 						Value: "email",
@@ -1951,6 +2111,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 36, Line: 3, Col: 1},
 								To:   Position{Index: 40, Line: 3, Col: 5},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 36, Line: 3, Col: 1},
+							To:   Position{Index: 48, Line: 3, Col: 13},
 						},
 					},
 				},
@@ -1979,6 +2143,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 20, Line: 0, Col: 20},
+						},
 					},
 				},
 				Range: Range{
@@ -2005,6 +2173,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 4, Line: 0, Col: 4},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 4, Line: 0, Col: 4},
+							To:   Position{Index: 20, Line: 0, Col: 20},
 						},
 					},
 					&BoolConstantAttribute{

--- a/parser/v2/raw_test.go
+++ b/parser/v2/raw_test.go
@@ -33,6 +33,10 @@ func TestRawElementParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 7, Line: 0, Col: 7},
+							To:   Position{Index: 22, Line: 0, Col: 22},
+						},
 					},
 				},
 				Contents: "contents",
@@ -56,6 +60,10 @@ func TestRawElementParser(t *testing.T) {
 								From: Position{Index: 7, Line: 0, Col: 7},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 7, Line: 0, Col: 7},
+							To:   Position{Index: 22, Line: 0, Col: 22},
 						},
 					},
 				},

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -91,6 +91,10 @@ func TestScriptElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 0, Col: 12},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 8, Line: 0, Col: 8},
+							To:   Position{Index: 23, Line: 0, Col: 23},
+						},
 					},
 				},
 				Contents: []ScriptContents{
@@ -131,6 +135,10 @@ func TestScriptElementParser(t *testing.T) {
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
 					},
+					Range: Range{
+						From: Position{Index: 8, Line: 0, Col: 8},
+						To:   Position{Index: 30, Line: 0, Col: 30},
+					},
 				}},
 				Contents: []ScriptContents{
 					NewScriptContentsGo(&GoCode{
@@ -161,6 +169,10 @@ func TestScriptElementParser(t *testing.T) {
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
 					},
+					Range: Range{
+						From: Position{Index: 8, Line: 0, Col: 8},
+						To:   Position{Index: 21, Line: 0, Col: 21},
+					},
 				}},
 				Contents: []ScriptContents{
 					NewScriptContentsGo(&GoCode{
@@ -190,6 +202,10 @@ func TestScriptElementParser(t *testing.T) {
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+					},
+					Range: Range{
+						From: Position{Index: 8, Line: 0, Col: 8},
+						To:   Position{Index: 25, Line: 0, Col: 25},
 					},
 				}},
 				Contents: []ScriptContents{
@@ -392,6 +408,10 @@ set tier_1 to #tier-1's value
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+					},
+					Range: Range{
+						From: Position{Index: 8, Line: 0, Col: 8},
+						To:   Position{Index: 31, Line: 0, Col: 31},
 					},
 				}},
 				Contents: []ScriptContents{

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -587,6 +587,10 @@ func TestTemplateParser(t *testing.T) {
 										To:   Position{Index: 38, Line: 1, Col: 12},
 									},
 								},
+								Range: Range{
+									From: Position{Index: 34, Line: 1, Col: 8},
+									To:   Position{Index: 45, Line: 1, Col: 19},
+								},
 							},
 							&ConstantAttribute{
 								Value: "a",
@@ -596,6 +600,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 46, Line: 1, Col: 20},
 										To:   Position{Index: 51, Line: 1, Col: 25},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 46, Line: 1, Col: 20},
+									To:   Position{Index: 55, Line: 1, Col: 29},
 								},
 							},
 						},
@@ -621,6 +629,10 @@ func TestTemplateParser(t *testing.T) {
 										To:   Position{Index: 71, Line: 2, Col: 12},
 									},
 								},
+								Range: Range{
+									From: Position{Index: 67, Line: 2, Col: 8},
+									To:   Position{Index: 78, Line: 2, Col: 19},
+								},
 							},
 							&ConstantAttribute{
 								Value: "b",
@@ -630,6 +642,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 79, Line: 2, Col: 20},
 										To:   Position{Index: 84, Line: 2, Col: 25},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 79, Line: 2, Col: 20},
+									To:   Position{Index: 88, Line: 2, Col: 29},
 								},
 							},
 						},
@@ -755,6 +771,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 16, Line: 1, Col: 4},
 										To:   Position{Index: 20, Line: 1, Col: 8},
 									},
+								},
+								Range: Range{
+									From: Position{Index: 16, Line: 1, Col: 4},
+									To:   Position{Index: 24, Line: 1, Col: 12},
 								},
 							},
 						},

--- a/parser/v2/templelementparser_test.go
+++ b/parser/v2/templelementparser_test.go
@@ -195,6 +195,10 @@ func TestTemplElementExpressionParser(t *testing.T) {
 										To:   Position{Index: 26, Line: 1, Col: 10},
 									},
 								},
+								Range: Range{
+									From: Position{Index: 22, Line: 1, Col: 6},
+									To:   Position{Index: 36, Line: 1, Col: 20},
+								},
 							},
 						},
 						TrailingSpace: SpaceVertical,

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -889,6 +889,7 @@ type ConstantAttribute struct {
 	Key         AttributeKey
 	Value       string
 	SingleQuote bool
+	Range       Range
 }
 
 func (ca *ConstantAttribute) String() string {
@@ -912,6 +913,7 @@ func (ca *ConstantAttribute) Copy() Attribute {
 		Value:       ca.Value,
 		SingleQuote: ca.SingleQuote,
 		Key:         ca.Key,
+		Range:       ca.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `ConstantAttribute` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, #1336, #1337, #1338, and #1340.