### PR TITLE
feat: add Range to ExpressionAttribute nodes

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -304,6 +304,7 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 		return
 	}
 
+	attrStart := pi.Index()
 	attr = &ExpressionAttribute{}
 
 	// Attribute name.
@@ -331,6 +332,8 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 		err = parse.Error("string expression attribute: missing closing brace", pi.Position())
 		return
 	}
+
+	attr.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 
 	return attr, true, nil
 })

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -276,6 +276,10 @@ if test {` + " " + `
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 40, Line: 4, Col: 1},
+							To:   Position{Index: 56, Line: 4, Col: 17},
+						},
 					},
 				},
 				Range: Range{
@@ -1092,6 +1096,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 3, Line: 0, Col: 3},
+							To:   Position{Index: 18, Line: 0, Col: 18},
+						},
 					},
 				},
 				Range: Range{
@@ -1322,6 +1330,10 @@ func TestElementParser(t *testing.T) {
 									Col:   50,
 								},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 15, Line: 0, Col: 15},
+							To:   Position{Index: 52, Line: 0, Col: 52},
 						},
 					},
 					&ConstantAttribute{
@@ -2052,6 +2064,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 45, Line: 0, Col: 45},
+							To:   Position{Index: 90, Line: 0, Col: 90},
+						},
 					},
 					&ConstantAttribute{
 						Value: "your@email.com",
@@ -2243,6 +2259,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 29, Line: 0, Col: 29},
+							To:   Position{Index: 54, Line: 0, Col: 54},
+						},
 					},
 				},
 				Range: Range{
@@ -2283,6 +2303,10 @@ func TestElementParser(t *testing.T) {
 									Col:   22,
 								},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 5, Line: 0, Col: 5},
+							To:   Position{Index: 24, Line: 0, Col: 24},
 						},
 					},
 				},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -950,6 +950,7 @@ func (bea *BoolExpressionAttribute) Copy() Attribute {
 type ExpressionAttribute struct {
 	Key        AttributeKey
 	Expression Expression
+	Range      Range
 }
 
 func (ea *ExpressionAttribute) String() string {
@@ -1012,6 +1013,7 @@ func (ea *ExpressionAttribute) Copy() Attribute {
 	return &ExpressionAttribute{
 		Expression: ea.Expression,
 		Key:        ea.Key,
+		Range:      ea.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `Range` to the parser's `ExpressionAttribute` nodes.

Continues @dgrundel's initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, #1336, #1337, #1338, #1340, and #1341.