### PR TITLE
feat: add Range to GoCode nodes

### DIFF
--- a/parser/v2/gocodeparser.go
+++ b/parser/v2/gocodeparser.go
@@ -17,6 +17,8 @@ var goCodeInJavaScript = getGoCodeParser(false)
 
 func getGoCodeParser(normalizeWhitespace bool) parse.Parser[Node] {
 	return parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
+		start := pi.Index()
+
 		// Check the prefix first.
 		if _, ok, err = dblOpenBraceWithOptionalPaddingOrNewLine.Parse(pi); err != nil || !ok {
 			return
@@ -54,6 +56,8 @@ func getGoCodeParser(normalizeWhitespace bool) parse.Parser[Node] {
 		} else {
 			r.TrailingSpace = TrailingSpace(ws)
 		}
+
+		r.Range = NewRange(pi.PositionAt(start), pi.Position())
 
 		return r, true, nil
 	})

--- a/parser/v2/gocodeparser_test.go
+++ b/parser/v2/gocodeparser_test.go
@@ -32,6 +32,13 @@ func TestGoCodeParser(t *testing.T) {
 						},
 					},
 				},
+				Range: Range{
+					To: Position{
+						Index: 17,
+						Line:  0,
+						Col:   17,
+					},
+				},
 			},
 		},
 		{
@@ -51,6 +58,13 @@ func TestGoCodeParser(t *testing.T) {
 							Line:  0,
 							Col:   11,
 						},
+					},
+				},
+				Range: Range{
+					To: Position{
+						Index: 13,
+						Line:  0,
+						Col:   13,
 					},
 				},
 			},
@@ -81,6 +95,13 @@ func TestGoCodeParser(t *testing.T) {
 					},
 				},
 				Multiline: true,
+				Range: Range{
+					To: Position{
+						Index: 51,
+						Line:  4,
+						Col:   5,
+					},
+				},
 			},
 		},
 		{
@@ -114,6 +135,13 @@ func TestGoCodeParser(t *testing.T) {
 				},
 				TrailingSpace: SpaceNone,
 				Multiline:     true,
+				Range: Range{
+					To: Position{
+						Index: 120,
+						Line:  6,
+						Col:   2,
+					},
+				},
 			},
 		},
 	}

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -115,6 +115,10 @@ func TestScriptElementParser(t *testing.T) {
 								To:   Position{Index: 15, Line: 0, Col: 15},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 8, Line: 0, Col: 8},
+							To:   Position{Index: 18, Line: 0, Col: 18},
+						},
 					}, false),
 				},
 				Range: Range{
@@ -148,6 +152,10 @@ func TestScriptElementParser(t *testing.T) {
 								From: Position{Index: 34, Line: 0, Col: 34},
 								To:   Position{Index: 38, Line: 0, Col: 38},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 31, Line: 0, Col: 31},
+							To:   Position{Index: 41, Line: 0, Col: 41},
 						},
 					}, false),
 				},
@@ -183,6 +191,10 @@ func TestScriptElementParser(t *testing.T) {
 								To:   Position{Index: 29, Line: 0, Col: 29},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 22, Line: 0, Col: 22},
+							To:   Position{Index: 32, Line: 0, Col: 32},
+						},
 					}, false),
 				},
 				Range: Range{
@@ -217,6 +229,10 @@ func TestScriptElementParser(t *testing.T) {
 								To:   Position{Index: 33, Line: 0, Col: 33},
 							},
 						},
+						Range: Range{
+							From: Position{Index: 26, Line: 0, Col: 26},
+							To:   Position{Index: 36, Line: 0, Col: 36},
+						},
 					}, false),
 				},
 				Range: Range{
@@ -242,6 +258,10 @@ func TestScriptElementParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						Range: Range{
+							From: Position{Index: 9, Line: 1, Col: 0},
+							To:   Position{Index: 20, Line: 2, Col: 0},
+						},
 					}, false),
 				},
 				Range: Range{
@@ -263,6 +283,10 @@ func TestScriptElementParser(t *testing.T) {
 								From: Position{Index: 20, Line: 0, Col: 20},
 								To:   Position{Index: 24, Line: 0, Col: 24},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 17, Line: 0, Col: 17},
+							To:   Position{Index: 27, Line: 0, Col: 27},
 						},
 					}, true),
 					NewScriptContentsScriptCode("';"),
@@ -286,6 +310,10 @@ func TestScriptElementParser(t *testing.T) {
 								From: Position{Index: 20, Line: 0, Col: 20},
 								To:   Position{Index: 24, Line: 0, Col: 24},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 17, Line: 0, Col: 17},
+							To:   Position{Index: 27, Line: 0, Col: 27},
 						},
 					}, true),
 					NewScriptContentsScriptCode("\";"),
@@ -313,6 +341,10 @@ to see if it works";</script>`,
 							},
 						},
 						TrailingSpace: SpaceHorizontal,
+						Range: Range{
+							From: Position{Index: 34, Line: 1, Col: 0},
+							To:   Position{Index: 45, Line: 1, Col: 11},
+						},
 					}, true),
 					NewScriptContentsScriptCode("\\\nto see if it works\";"),
 				},
@@ -335,6 +367,10 @@ to see if it works";</script>`,
 								From: Position{Index: 20, Line: 0, Col: 20},
 								To:   Position{Index: 24, Line: 0, Col: 24},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 17, Line: 0, Col: 17},
+							To:   Position{Index: 27, Line: 0, Col: 27},
 						},
 					}, true),
 					NewScriptContentsScriptCode("`;"),
@@ -434,6 +470,10 @@ const result = call(1000 / 10, {{ data }}, 1000 / 10);
 								From: Position{Index: 43, Line: 1, Col: 34},
 								To:   Position{Index: 47, Line: 1, Col: 38},
 							},
+						},
+						Range: Range{
+							From: Position{Index: 40, Line: 1, Col: 31},
+							To:   Position{Index: 50, Line: 1, Col: 41},
 						},
 					}, false),
 					NewScriptContentsScriptCode(", 1000 / 10);\n"),

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -1433,6 +1433,7 @@ type GoCode struct {
 	// TrailingSpace lists what happens after the expression.
 	TrailingSpace TrailingSpace
 	Multiline     bool
+	Range         Range
 }
 
 func (gc *GoCode) Trailing() TrailingSpace {


### PR DESCRIPTION
Adds a `Range` to the parser's `GoCode` nodes.

Continues the initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302,  #1335, #1336, #1337, #1338, #1340, #1341, and #1347.