### PR TITLE
fix: track Range for non-JavaScript ScriptExpression nodes

### DIFF
--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -68,6 +68,7 @@ func (p scriptElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error)
 		// Cut the end element.
 		_, _, _ = jsEndTag.Parse(pi)
 
+		e.Range = NewRange(pi.PositionAt(start), pi.Position())
 		return e, true, nil
 	}
 

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -100,6 +100,10 @@ func TestScriptElementParser(t *testing.T) {
 				Contents: []ScriptContents{
 					NewScriptContentsScriptCode("dim x = 1"),
 				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 42, Line: 0, Col: 42},
+				},
 			},
 		},
 		{
@@ -416,6 +420,10 @@ set tier_1 to #tier-1's value
 				}},
 				Contents: []ScriptContents{
 					NewScriptContentsScriptCode("\nset tier_1 to #tier-1's value\n"),
+				},
+				Range: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 72, Line: 2, Col: 9},
 				},
 			},
 		},


### PR DESCRIPTION
71566a083d48ce796129f966b01e4dd131ea4b59 / #1231 added `Range` to `ScriptExpression` nodes, but only for `<script>` elements with a JavaScript `type` (as decided by `hasJavaScriptType`). This commit tracks `Range` for `<script>` elements with _non_-Javascript `type`s.

See also #1301, #1302,  #1335, #1336, #1337, #1338, #1340, #1341, #1347, #1348, and #1349.