### PR TITLE
fix: strip superfluous whitespace from class attribute values

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1189,6 +1189,15 @@ func (g *generator) writeBoolConstantAttribute(indentLevel int, attr *parser.Boo
 	return g.writeAttributeKey(indentLevel, attr.Key)
 }
 
+// normalizeClassValue collapses all sequences of whitespace characters (spaces,
+// tabs, newlines) into a single space and trims leading/trailing whitespace.
+// This reduces the size of the generated HTML without changing the semantics of
+// the class attribute, since class names are whitespace-separated tokens.
+func normalizeClassValue(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
 func (g *generator) writeConstantAttribute(indentLevel int, attr *parser.ConstantAttribute) (err error) {
 	if err = g.writeAttributeKey(indentLevel, attr.Key); err != nil {
 		return err
@@ -1197,7 +1206,11 @@ func (g *generator) writeConstantAttribute(indentLevel int, attr *parser.Constan
 	if attr.SingleQuote {
 		quote = "'"
 	}
-	value := escapeQuotes("=" + quote + attr.Value + quote)
+	attrValue := attr.Value
+	if k, ok := attr.Key.(parser.ConstantAttributeKey); ok && k.Name == "class" {
+		attrValue = normalizeClassValue(attrValue)
+	}
+	value := escapeQuotes("=" + quote + attrValue + quote)
 	if _, err = g.w.WriteStringLiteral(indentLevel, value); err != nil {
 		return err
 	}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -105,3 +105,50 @@ func TestIsExpressionAttributeValueURL(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeClassValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single line unchanged",
+			input:    "flex w-full h-full",
+			expected: "flex w-full h-full",
+		},
+		{
+			name:     "multiline with tabs",
+			input:    "\n\t\t\tflex w-full h-full\n\t\t\tjustify-center items-center\n\t\t\thover:bg-blue-50\n\t\t",
+			expected: "flex w-full h-full justify-center items-center hover:bg-blue-50",
+		},
+		{
+			name:     "leading and trailing whitespace",
+			input:    "  foo  bar  baz  ",
+			expected: "foo bar baz",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only whitespace",
+			input:    "  \t\n  ",
+			expected: "",
+		},
+		{
+			name:     "single class",
+			input:    "active",
+			expected: "active",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeClassValue(tc.input)
+			if got != tc.expected {
+				t.Errorf("normalizeClassValue(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Collapse sequences of whitespace characters (spaces, tabs, newlines) in constant `class` attribute values into a single space during code generation. This reduces the size of the generated HTML without changing semantics, since HTML class lists are whitespace-separated tokens.

## Why

When writing multi-line class lists for readability:

```html
<div
    class="
        flex w-full h-full
        justify-center items-center
        hover:bg-blue-50
    "
>
```

templ previously preserved all whitespace verbatim in the generated Go code, producing:

```html
<div class="\n\t\t\t\tflex w-full h-full\n\t\t\t\tjustify-center items-center\n\t\t\t\thover:bg-blue-50\n\t\t\t">
```

With this change, the output is now:

```html
<div class="flex w-full h-full justify-center items-center hover:bg-blue-50">
```

## Upstream issue

Fixes [a-h/templ#1074](https://github.com/a-h/templ/issues/1074)

## Changes

- Added `normalizeClassValue()` helper in `generator/generator.go` that uses `strings.Fields`/`strings.Join` to collapse whitespace
- Applied normalization in `writeConstantAttribute` only when the attribute key is `class`
- Added unit tests for the normalization function

Note: this entire change was AI-generated.