### PR TITLE
Adding coverage reporting for Templ files (part 1/3)

### DIFF
--- a/runtime/coverage.go
+++ b/runtime/coverage.go
@@ -1,0 +1,213 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Position represents a source location in a template file
+type Position struct {
+	Line uint32 `json:"line"`
+	Col  uint32 `json:"col"`
+}
+
+// CoveragePoint represents a single coverage measurement
+type CoveragePoint struct {
+	Line uint32 `json:"line"`
+	Col  uint32 `json:"col"`
+	Hits uint32 `json:"hits"`
+	Type string `json:"type"`
+}
+
+// CoverageProfile represents the JSON coverage output format
+type CoverageProfile struct {
+	Version string                     `json:"version"`
+	Mode    string                     `json:"mode"`
+	Files   map[string][]CoveragePoint `json:"files"`
+}
+
+// CoverageRegistry tracks coverage data during test execution
+type CoverageRegistry struct {
+	mu       sync.Mutex
+	files    map[string]map[Position]uint32 // filename → position → hit count
+	coverDir string                         // captured at init time, used at flush time
+}
+
+var (
+	coverageRegistry *CoverageRegistry
+	coverageOnce     sync.Once
+)
+
+// EnableCoverage initializes the coverage registry for non-test use cases (e.g. servers).
+// For test binaries, use RunWithCoverage instead.
+// Unlike the old EnableCoverageForTesting(), this requires TEMPLCOVERDIR to be set —
+// it won't initialize the registry without a target directory.
+func EnableCoverage() {
+	dir := os.Getenv("TEMPLCOVERDIR")
+	if dir == "" {
+		return
+	}
+	coverageOnce.Do(func() {
+		coverageRegistry = &CoverageRegistry{
+			files:    make(map[string]map[Position]uint32),
+			coverDir: dir,
+		}
+	})
+}
+
+// TestRunner is implemented by *testing.M (which has a Run() method).
+type TestRunner interface {
+	Run() int
+}
+
+// RunWithCoverage wraps m.Run() with coverage lifecycle management.
+// If TEMPLCOVERDIR is not set, it calls m.Run() directly with zero overhead.
+// Safe to leave in permanently — it's a no-op without TEMPLCOVERDIR.
+func RunWithCoverage(m TestRunner) int {
+	dir := os.Getenv("TEMPLCOVERDIR")
+	if dir == "" {
+		return m.Run()
+	}
+
+	coverageOnce.Do(func() {
+		coverageRegistry = &CoverageRegistry{
+			files:    make(map[string]map[Position]uint32),
+			coverDir: dir,
+		}
+	})
+
+	done := make(chan struct{})
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigChan:
+			_ = coverageRegistry.Flush()
+			os.Exit(1)
+		case <-done:
+			return
+		}
+	}()
+
+	code := m.Run()
+
+	signal.Stop(sigChan)
+	close(done)
+	_ = coverageRegistry.Flush()
+	return code
+}
+
+// CoverageSnapshot returns a deep copy of current coverage data.
+// Returns nil if coverage is not enabled. Thread-safe.
+func CoverageSnapshot() map[string][]CoveragePoint {
+	if coverageRegistry == nil {
+		return nil
+	}
+	coverageRegistry.mu.Lock()
+	defer coverageRegistry.mu.Unlock()
+
+	result := make(map[string][]CoveragePoint, len(coverageRegistry.files))
+	for filename, positions := range coverageRegistry.files {
+		points := make([]CoveragePoint, 0, len(positions))
+		for pos, hits := range positions {
+			points = append(points, CoveragePoint{
+				Line: pos.Line,
+				Col:  pos.Col,
+				Hits: hits,
+			})
+		}
+		result[filename] = points
+	}
+	return result
+}
+
+// Record increments the hit count for a coverage point
+func (r *CoverageRegistry) Record(filename string, line, col uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.files[filename] == nil {
+		r.files[filename] = make(map[Position]uint32)
+	}
+
+	pos := Position{Line: line, Col: col}
+	r.files[filename][pos]++
+}
+
+// CoverageTrack records that a coverage point was executed
+// Called by generated template code when coverage is enabled
+func CoverageTrack(filename string, line, col uint32) {
+	if coverageRegistry == nil {
+		return // No-op if coverage disabled
+	}
+	coverageRegistry.Record(filename, line, col)
+}
+
+// WriteProfile writes coverage data to a JSON file
+func (r *CoverageRegistry) WriteProfile(path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	profile := CoverageProfile{
+		Version: "1",
+		Mode:    "count",
+		Files:   make(map[string][]CoveragePoint),
+	}
+
+	// Convert internal map to slice format
+	for filename, positions := range r.files {
+		points := make([]CoveragePoint, 0, len(positions))
+		for pos, hits := range positions {
+			points = append(points, CoveragePoint{
+				Line: pos.Line,
+				Col:  pos.Col,
+				Hits: hits,
+				Type: "expression", // Default type for now
+			})
+		}
+		profile.Files[filename] = points
+	}
+
+	// Write JSON
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write profile: %w", err)
+	}
+
+	return nil
+}
+
+// Flush writes the coverage profile to disk
+func (r *CoverageRegistry) Flush() error {
+	if r.coverDir == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(r.coverDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	filename := fmt.Sprintf("templ-%d-%d.json", os.Getpid(), time.Now().UnixNano())
+	path := filepath.Join(r.coverDir, filename)
+
+	return r.WriteProfile(path)
+}
+
+// FlushCoverage explicitly flushes coverage data to disk
+// Tests should call this in cleanup to ensure profiles are written
+func FlushCoverage() error {
+	if coverageRegistry == nil {
+		return nil
+	}
+	return coverageRegistry.Flush()
+}

--- a/runtime/coverage_test.go
+++ b/runtime/coverage_test.go
@@ -1,0 +1,299 @@
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// withFreshRegistry saves and restores the global coverage state.
+func withFreshRegistry(t *testing.T) {
+	t.Helper()
+	old := coverageRegistry
+	t.Cleanup(func() {
+		coverageRegistry = old
+		coverageOnce = sync.Once{}
+	})
+	coverageRegistry = nil
+	coverageOnce = sync.Once{}
+}
+
+func TestEnableCoverage_InitializesWhenEnvSet(t *testing.T) {
+	withFreshRegistry(t)
+	t.Setenv("TEMPLCOVERDIR", t.TempDir())
+
+	EnableCoverage()
+
+	if coverageRegistry == nil {
+		t.Error("expected registry to initialize when TEMPLCOVERDIR set")
+	}
+	if coverageRegistry.coverDir == "" {
+		t.Error("expected coverDir to be set")
+	}
+}
+
+func TestEnableCoverage_NilWhenEnvUnset(t *testing.T) {
+	withFreshRegistry(t)
+	t.Setenv("TEMPLCOVERDIR", "")
+
+	EnableCoverage()
+
+	if coverageRegistry != nil {
+		t.Error("expected registry to be nil when TEMPLCOVERDIR unset")
+	}
+}
+
+func TestCoverageRegistry_Record(t *testing.T) {
+	reg := &CoverageRegistry{
+		files: make(map[string]map[Position]uint32),
+	}
+
+	// Record same position twice
+	reg.Record("test.templ", 5, 10)
+	reg.Record("test.templ", 5, 10)
+
+	// Record different position
+	reg.Record("test.templ", 7, 3)
+
+	// Verify hit counts
+	pos1 := Position{Line: 5, Col: 10}
+	if hits := reg.files["test.templ"][pos1]; hits != 2 {
+		t.Errorf("expected 2 hits for position (5,10), got %d", hits)
+	}
+
+	pos2 := Position{Line: 7, Col: 3}
+	if hits := reg.files["test.templ"][pos2]; hits != 1 {
+		t.Errorf("expected 1 hit for position (7,3), got %d", hits)
+	}
+}
+
+func TestCoverageRegistry_RecordConcurrent(t *testing.T) {
+	reg := &CoverageRegistry{
+		files: make(map[string]map[Position]uint32),
+	}
+
+	// Concurrent writes to same position
+	const goroutines = 100
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				reg.Record("test.templ", 5, 10)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	pos := Position{Line: 5, Col: 10}
+	expected := uint32(goroutines * iterations)
+	if hits := reg.files["test.templ"][pos]; hits != expected {
+		t.Errorf("expected %d hits, got %d (data race?)", expected, hits)
+	}
+}
+
+func TestCoverageTrack_NoOpWhenDisabled(t *testing.T) {
+	withFreshRegistry(t)
+
+	// Should not panic
+	CoverageTrack("test.templ", 5, 10)
+}
+
+func TestCoverageTrack_RecordsWhenEnabled(t *testing.T) {
+	oldRegistry := coverageRegistry
+	t.Cleanup(func() { coverageRegistry = oldRegistry })
+
+	coverageRegistry = &CoverageRegistry{
+		files: make(map[string]map[Position]uint32),
+	}
+
+	CoverageTrack("test.templ", 5, 10)
+
+	pos := Position{Line: 5, Col: 10}
+	if hits := coverageRegistry.files["test.templ"][pos]; hits != 1 {
+		t.Errorf("expected 1 hit, got %d", hits)
+	}
+}
+
+func TestCoverageRegistry_WriteProfile(t *testing.T) {
+	reg := &CoverageRegistry{
+		files: make(map[string]map[Position]uint32),
+	}
+
+	reg.Record("test.templ", 5, 10)
+	reg.Record("test.templ", 7, 3)
+	reg.Record("other.templ", 2, 1)
+
+	tmpFile := filepath.Join(t.TempDir(), "profile.json")
+
+	if err := reg.WriteProfile(tmpFile); err != nil {
+		t.Fatalf("WriteProfile failed: %v", err)
+	}
+
+	// Read and parse JSON
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read profile: %v", err)
+	}
+
+	var profile CoverageProfile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	// Verify structure
+	if profile.Version != "1" {
+		t.Errorf("expected version 1, got %s", profile.Version)
+	}
+
+	if profile.Mode != "count" {
+		t.Errorf("expected mode count, got %s", profile.Mode)
+	}
+
+	// Verify test.templ has 2 coverage points
+	if len(profile.Files["test.templ"]) != 2 {
+		t.Errorf("expected 2 points for test.templ, got %d", len(profile.Files["test.templ"]))
+	}
+
+	// Verify other.templ has 1 coverage point
+	if len(profile.Files["other.templ"]) != 1 {
+		t.Errorf("expected 1 point for other.templ, got %d", len(profile.Files["other.templ"]))
+	}
+}
+
+func TestCoverageRegistry_Flush(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	reg := &CoverageRegistry{
+		files:    make(map[string]map[Position]uint32),
+		coverDir: tmpDir,
+	}
+	reg.Record("test.templ", 5, 10)
+
+	if err := reg.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(tmpDir, "templ-*.json"))
+	if err != nil {
+		t.Fatalf("failed to glob files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 profile file, found %d", len(files))
+	}
+}
+
+type mockRunner struct {
+	code int
+}
+
+func (m *mockRunner) Run() int { return m.code }
+
+func TestRunWithCoverage_NoOpWithoutEnv(t *testing.T) {
+	withFreshRegistry(t)
+	t.Setenv("TEMPLCOVERDIR", "")
+
+	code := RunWithCoverage(&mockRunner{code: 0})
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+	if coverageRegistry != nil {
+		t.Error("expected registry to remain nil without TEMPLCOVERDIR")
+	}
+}
+
+func TestRunWithCoverage_InitializesAndFlushes(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("TEMPLCOVERDIR", tmpDir)
+
+	withFreshRegistry(t)
+
+	// Verify exit code is propagated
+	code := RunWithCoverage(&mockRunner{code: 42})
+	if code != 42 {
+		t.Errorf("expected exit code 42, got %d", code)
+	}
+	if coverageRegistry == nil {
+		t.Fatal("expected registry to be initialized")
+	}
+
+	files, err := filepath.Glob(filepath.Join(tmpDir, "templ-*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 profile file, found %d", len(files))
+	}
+}
+
+func TestFlushCoverage(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("TEMPLCOVERDIR", tmpDir)
+
+	withFreshRegistry(t)
+	EnableCoverage()
+
+	CoverageTrack("test.templ", 5, 10)
+
+	if err := FlushCoverage(); err != nil {
+		t.Fatalf("FlushCoverage failed: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(tmpDir, "templ-*.json"))
+	if err != nil {
+		t.Fatalf("failed to glob files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 profile file after explicit flush, found %d", len(files))
+	}
+
+	// FlushCoverage when disabled should be a no-op
+	withFreshRegistry(t)
+	if err := FlushCoverage(); err != nil {
+		t.Errorf("FlushCoverage should return nil when disabled, got %v", err)
+	}
+}
+
+func TestCoverageSnapshot_ReturnsNilWhenDisabled(t *testing.T) {
+	withFreshRegistry(t)
+
+	snap := CoverageSnapshot()
+	if snap != nil {
+		t.Error("expected nil snapshot when coverage disabled")
+	}
+}
+
+func TestCoverageSnapshot_ReturnsDeepCopy(t *testing.T) {
+	oldRegistry := coverageRegistry
+	t.Cleanup(func() { coverageRegistry = oldRegistry })
+
+	coverageRegistry = &CoverageRegistry{
+		files: make(map[string]map[Position]uint32),
+	}
+	CoverageTrack("test.templ", 5, 10)
+	CoverageTrack("test.templ", 5, 10)
+	CoverageTrack("test.templ", 7, 3)
+
+	snap := CoverageSnapshot()
+	if snap == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+
+	points := snap["test.templ"]
+	if len(points) != 2 {
+		t.Fatalf("expected 2 points, got %d", len(points))
+	}
+
+	// Verify it's a deep copy: mutating snap shouldn't affect registry
+	snap["test.templ"] = nil
+	snap2 := CoverageSnapshot()
+	if len(snap2["test.templ"]) != 2 {
+		t.Error("snapshot was not a deep copy")
+	}
+}


### PR DESCRIPTION
Hey all, 
I was playing around with the SourceMap infrastructure to see if it could support some reverse-engineering of a templ coverage report by taking the Go coverage and mapping it back to templ lines. I quickly realized it wouldn't be as simple as I thought:
1. Sourcemaps seem only implemented to the extend needed to support LSP operations
2. A single templ statement like a spread operator maps to many lines of Go, making it harder to map go coverage back to templ. 
3. Even if these worked, we'd still need custom tooling for generating reports anyway

Instead of trying to make this all work, we could track what lines are executed at runtime in the generated code itself, marking templ lines as they're executed in Go. This involves modifying the generated code to instrument it with some tracking statements and flushing those out when the test finishes execution.

The full workflow for users is:

1. Add `RunWithCoverage` to `TestMain` (one-time setup per test package)
2. Run `templ generate --coverage` before tests //opt-in to capturing tracking information
3. Set `TEMPLCOVERDIR` when running tests // opt-in to writing out the profile info
4. Run `templ coverage report` to see results

I've been playing with this and have a [prototype](https://github.com/a-h/templ/compare/main...whalenrp:templ:coverage-v1-3?expand=1) together. The HTML reporting is not included in that stack, but I wanted to show you how it looks end-to-end 
<img width="568" height="825" alt="Screenshot 2026-03-22 at 9 42 00 PM" src="https://github.com/user-attachments/assets/c21b391a-e933-4e19-8357-944931b1c21e" />


This diff specifically includes just the code needed to track, collect, and flush out the coverage data if you agree with the overall idea. I'm happy to make any changes in the approach if you all have suggestions of course.