### PR TITLE
fix: use dedicated shadow host in Suspense example to ensure header is rendered

### DIFF
--- a/docs/docs/05-server-side-rendering/05-streaming.md
+++ b/docs/docs/05-server-side-rendering/05-streaming.md
@@ -119,20 +119,22 @@ templ Page(data chan SlotContents) {
 		</head>
 		<body>
 			<h1>Page</h1>
-			@templ.Flush() {
-				<template shadowrootmode="open">
-					@Slot("a")
-					@Slot("b")
-					@Slot("c")
-				</template>
-			}
-			for sc := range data {
+			<div>
 				@templ.Flush() {
-					<div slot={ sc.Name }>
-						@sc.Contents
-					</div>
+					<template shadowrootmode="open">
+						@Slot("a")
+						@Slot("b")
+						@Slot("c")
+					</template>
 				}
-			}
+				for sc := range data {
+					@templ.Flush() {
+						<div slot={ sc.Name }>
+							@sc.Contents
+						</div>
+					}
+				}
+			</div>
 		</body>
 	</html>
 }

--- a/examples/suspense/main.templ
+++ b/examples/suspense/main.templ
@@ -92,20 +92,22 @@ templ Page(data chan SlotContents) {
 		</head>
 		<body>
 			<h1>Page</h1>
-			@templ.Flush() {
-				<template shadowrootmode="open">
-					@Slot("a")
-					@Slot("b")
-					@Slot("c")
-				</template>
-			}
-			for sc := range data {
+			<div>
 				@templ.Flush() {
-					<div slot={ sc.Name }>
-						@sc.Contents
-					</div>
+					<template shadowrootmode="open">
+						@Slot("a")
+						@Slot("b")
+						@Slot("c")
+					</template>
 				}
-			}
+				for sc := range data {
+					@templ.Flush() {
+						<div slot={ sc.Name }>
+							@sc.Contents
+						</div>
+					}
+				}
+			</div>
 		</body>
 	</html>
 }

--- a/examples/suspense/main_templ.go
+++ b/examples/suspense/main_templ.go
@@ -236,7 +236,7 @@ func Page(data chan SlotContents) templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<!doctype html><html><head><title>Page</title></head><body><h1>Page</h1>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<!doctype html><html><head><title>Page</title></head><body><h1>Page</h1><div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -298,7 +298,7 @@ func Page(data chan SlotContents) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(sc.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `examples/suspense/main.templ`, Line: 104, Col: 24}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `examples/suspense/main.templ`, Line: 105, Col: 25}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -323,7 +323,7 @@ func Page(data chan SlotContents) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Fixes #1357.

When the declarative shadow DOM creates a shadow root it makes the element it's in the shadow host. Any existing content is replaced, so add a dedicated shadow host element to avoid accidental missing content (the `h1` in this example).

The alternative to this fix would be to remove the `h1` element entirely and have the `body` element as the intended shadow host.