### PR TITLE
fix(generatecmd): check `cmd.Start()` error before inserting `cmd` in to `running` map

### DIFF
--- a/cmd/templ/generatecmd/run/run_unix.go
+++ b/cmd/templ/generatecmd/run/run_unix.go
@@ -79,7 +79,12 @@ func Run(ctx context.Context, workingDir string, input string) (cmd *exec.Cmd, e
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return cmd, err
+	}
+
 	running[input] = cmd
-	err = cmd.Start()
+
 	return
 }

--- a/cmd/templ/generatecmd/run/run_unix.go
+++ b/cmd/templ/generatecmd/run/run_unix.go
@@ -83,8 +83,6 @@ func Run(ctx context.Context, workingDir string, input string) (cmd *exec.Cmd, e
 	if err := cmd.Start(); err != nil {
 		return cmd, err
 	}
-
 	running[input] = cmd
-
-	return
+	return cmd, nil
 }

--- a/cmd/templ/generatecmd/run/run_windows.go
+++ b/cmd/templ/generatecmd/run/run_windows.go
@@ -66,7 +66,12 @@ func Run(ctx context.Context, workingDir string, input string) (cmd *exec.Cmd, e
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return cmd, err
+	}
+
 	running[input] = cmd
-	err = cmd.Start()
+
 	return
 }

--- a/cmd/templ/generatecmd/run/run_windows.go
+++ b/cmd/templ/generatecmd/run/run_windows.go
@@ -70,8 +70,6 @@ func Run(ctx context.Context, workingDir string, input string) (cmd *exec.Cmd, e
 	if err := cmd.Start(); err != nil {
 		return cmd, err
 	}
-
 	running[input] = cmd
-
-	return
+	return cmd, nil
 }


### PR DESCRIPTION
Fixes a logic bug where `cmd` was inserted into `running` map even if `cmd.Start()` returned an error, which results in a panic when such `cmd` is used in `kill` function.