### PR TITLE
feat: add ranges for attribute node values

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -317,6 +317,7 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 	}
 
 	if _, _, err = parse.OptionalWhitespace.Parse(pi); err != nil {
+		pi.Seek(start)
 		return attr, false, err
 	}
 
@@ -327,6 +328,7 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 	}
 
 	if _, _, err = parse.OptionalWhitespace.Parse(pi); err != nil {
+		pi.Seek(start)
 		return attr, false, err
 	}
 
@@ -336,6 +338,7 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 	}
 
 	if _, _, err = parse.OptionalWhitespace.Parse(pi); err != nil {
+		pi.Seek(start)
 		return attr, false, err
 	}
 
@@ -353,7 +356,7 @@ var expressionAttributeParser = parse.Func(func(pi *parse.Input) (attr *Expressi
 		return
 	}
 	initializerEndIndex := pi.Index()
-	attr.InitializerRange = NewRange(pi.PositionAt(initializerStartIndex), pi.PositionAt(initializerEndIndex))
+	attr.AttributeStartRange = NewRange(pi.PositionAt(initializerStartIndex), pi.PositionAt(initializerEndIndex))
 
 	attr.Range = NewRange(pi.PositionAt(attrStart), pi.Position())
 

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -61,6 +61,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 6, Line: 0, Col: 6},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 8, Line: 0, Col: 8},
+							To:   Position{Index: 19, Line: 0, Col: 19},
+						},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},
 							To:   Position{Index: 20, Line: 0, Col: 20},
@@ -89,6 +93,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 13, Line: 0, Col: 13},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},
 							To:   Position{Index: 25, Line: 0, Col: 25},
@@ -102,6 +110,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 26, Line: 0, Col: 26},
 								To:   Position{Index: 32, Line: 0, Col: 32},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 34, Line: 0, Col: 34},
+							To:   Position{Index: 47, Line: 0, Col: 47},
 						},
 						Range: Range{
 							From: Position{Index: 26, Line: 0, Col: 26},
@@ -131,6 +143,10 @@ func TestAttributeParser(t *testing.T) {
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 9, Line: 0, Col: 9},
+							To:   Position{Index: 12, Line: 0, Col: 12},
+						},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},
 							To:   Position{Index: 13, Line: 0, Col: 13},
@@ -144,6 +160,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 14, Line: 0, Col: 14},
 								To:   Position{Index: 19, Line: 0, Col: 19},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 21, Line: 0, Col: 21},
+							To:   Position{Index: 34, Line: 0, Col: 34},
 						},
 						Range: Range{
 							From: Position{Index: 14, Line: 0, Col: 14},
@@ -186,6 +206,10 @@ func TestAttributeParser(t *testing.T) {
 								From: Position{Index: 23, Line: 2, Col: 3},
 								To:   Position{Index: 28, Line: 2, Col: 8},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 30, Line: 2, Col: 10},
+							To:   Position{Index: 39, Line: 2, Col: 19},
 						},
 						Range: Range{
 							From: Position{Index: 23, Line: 2, Col: 3},
@@ -235,6 +259,10 @@ if test {` + " " + `
 								To:   Position{Index: 18, Line: 2, Col: 6},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 20, Line: 2, Col: 8},
+							To:   Position{Index: 28, Line: 2, Col: 16},
+						},
 						Range: Range{
 							From: Position{Index: 13, Line: 2, Col: 1},
 							To:   Position{Index: 29, Line: 2, Col: 17},
@@ -275,6 +303,10 @@ if test {` + " " + `
 									Col:   15,
 								},
 							},
+						},
+						InitializerRange: Range{
+							From: Position{Index: 44, Line: 4, Col: 5},
+							To:   Position{Index: 56, Line: 4, Col: 17},
 						},
 						Range: Range{
 							From: Position{Index: 40, Line: 4, Col: 1},
@@ -459,6 +491,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 11, Line: 0, Col: 11},
+				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 12, Line: 0, Col: 12},
@@ -478,6 +514,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 31, Line: 0, Col: 31},
 				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
@@ -499,6 +539,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 13, Line: 0, Col: 13},
+				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 14, Line: 0, Col: 14},
@@ -518,6 +562,10 @@ if test {` + " " + `
 						To:   Position{Index: 21, Line: 0, Col: 21},
 					},
 				},
+				ValueRange: Range{
+					From: Position{Index: 23, Line: 0, Col: 23},
+					To:   Position{Index: 28, Line: 0, Col: 28},
+				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 29, Line: 0, Col: 29},
@@ -536,6 +584,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 7, Line: 0, Col: 7},
 				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
@@ -558,6 +610,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 12, Line: 0, Col: 12},
 					},
+				},
+				ValueRange: Range{
+					From: Position{Index: 14, Line: 0, Col: 14},
+					To:   Position{Index: 68, Line: 2, Col: 16},
 				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
@@ -708,6 +764,10 @@ if test {` + " " + `
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
 				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 8, Line: 0, Col: 8},
+				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 9, Line: 0, Col: 9},
@@ -726,6 +786,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				ValueRange: Range{
+					From: Position{Index: 7, Line: 0, Col: 7},
+					To:   Position{Index: 12, Line: 0, Col: 12},
 				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
@@ -746,6 +810,10 @@ if test {` + " " + `
 						To:   Position{Index: 12, Line: 0, Col: 12},
 					},
 				},
+				ValueRange: Range{
+					From: Position{Index: 14, Line: 0, Col: 14},
+					To:   Position{Index: 21, Line: 0, Col: 21},
+				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 22, Line: 0, Col: 22},
@@ -764,6 +832,10 @@ if test {` + " " + `
 						From: Position{Index: 1, Line: 0, Col: 1},
 						To:   Position{Index: 5, Line: 0, Col: 5},
 					},
+				},
+				ValueRange: Range{
+					From: Position{Index: 6, Line: 0, Col: 6},
+					To:   Position{Index: 9, Line: 0, Col: 9},
 				},
 				Range: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
@@ -828,6 +900,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 3, Line: 0, Col: 3},
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 9, Line: 0, Col: 9},
+							To:   Position{Index: 13, Line: 0, Col: 13},
 						},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
@@ -1096,6 +1172,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						InitializerRange: Range{
+							From: Position{Index: 7, Line: 0, Col: 7},
+							To:   Position{Index: 18, Line: 0, Col: 18},
+						},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 18, Line: 0, Col: 18},
@@ -1127,6 +1207,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 9, Line: 0, Col: 9},
+							To:   Position{Index: 13, Line: 0, Col: 13},
+						},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 14, Line: 0, Col: 14},
@@ -1140,6 +1224,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 15, Line: 0, Col: 15},
 								To:   Position{Index: 20, Line: 0, Col: 20},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 22, Line: 0, Col: 22},
+							To:   Position{Index: 42, Line: 0, Col: 42},
 						},
 						Range: Range{
 							From: Position{Index: 15, Line: 0, Col: 15},
@@ -1272,6 +1360,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 37, Line: 0, Col: 37},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 39, Line: 0, Col: 39},
+							To:   Position{Index: 44, Line: 0, Col: 44},
+						},
 						Range: Range{
 							From: Position{Index: 30, Line: 0, Col: 30},
 							To:   Position{Index: 45, Line: 0, Col: 45},
@@ -1303,6 +1395,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 7, Line: 0, Col: 7},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 9, Line: 0, Col: 9},
+							To:   Position{Index: 13, Line: 0, Col: 13},
+						},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 14, Line: 0, Col: 14},
@@ -1331,6 +1427,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						InitializerRange: Range{
+							From: Position{Index: 20, Line: 0, Col: 20},
+							To:   Position{Index: 52, Line: 0, Col: 52},
+						},
 						Range: Range{
 							From: Position{Index: 15, Line: 0, Col: 15},
 							To:   Position{Index: 52, Line: 0, Col: 52},
@@ -1344,6 +1444,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 53, Line: 0, Col: 53},
 								To:   Position{Index: 58, Line: 0, Col: 58},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 60, Line: 0, Col: 60},
+							To:   Position{Index: 80, Line: 0, Col: 80},
 						},
 						Range: Range{
 							From: Position{Index: 53, Line: 0, Col: 53},
@@ -1383,6 +1487,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 10, Line: 0, Col: 10},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 12, Line: 0, Col: 12},
+							To:   Position{Index: 23, Line: 0, Col: 23},
+						},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},
 							To:   Position{Index: 24, Line: 0, Col: 24},
@@ -1413,6 +1521,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 47, Line: 2, Col: 3},
 										To:   Position{Index: 52, Line: 2, Col: 8},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 54, Line: 2, Col: 10},
+									To:   Position{Index: 63, Line: 2, Col: 19},
 								},
 								Range: Range{
 									From: Position{Index: 47, Line: 2, Col: 3},
@@ -1477,6 +1589,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 11, Line: 0, Col: 11},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 25, Line: 0, Col: 25},
@@ -1512,6 +1628,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 11, Line: 0, Col: 11},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 25, Line: 0, Col: 25},
@@ -1542,6 +1662,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 44, Line: 2, Col: 4},
 										To:   Position{Index: 49, Line: 2, Col: 9},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 51, Line: 2, Col: 11},
+									To:   Position{Index: 59, Line: 2, Col: 19},
 								},
 								Range: Range{
 									From: Position{Index: 44, Line: 2, Col: 4},
@@ -1587,6 +1711,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 9, Line: 0, Col: 9},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 11, Line: 0, Col: 11},
+							To:   Position{Index: 24, Line: 0, Col: 24},
+						},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 25, Line: 0, Col: 25},
@@ -1618,6 +1746,10 @@ func TestElementParser(t *testing.T) {
 										To:   Position{Index: 49, Line: 2, Col: 9},
 									},
 								},
+								ValueRange: Range{
+									From: Position{Index: 51, Line: 2, Col: 11},
+									To:   Position{Index: 59, Line: 2, Col: 19},
+								},
 								Range: Range{
 									From: Position{Index: 44, Line: 2, Col: 4},
 									To:   Position{Index: 60, Line: 2, Col: 20},
@@ -1633,6 +1765,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 77, Line: 4, Col: 4},
 										To:   Position{Index: 82, Line: 4, Col: 9},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 84, Line: 4, Col: 11},
+									To:   Position{Index: 95, Line: 4, Col: 22},
 								},
 								Range: Range{
 									From: Position{Index: 77, Line: 4, Col: 4},
@@ -1676,6 +1812,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 8, Line: 0, Col: 8},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 10, Line: 0, Col: 10},
+							To:   Position{Index: 23, Line: 0, Col: 23},
+						},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 24, Line: 0, Col: 24},
@@ -1706,6 +1846,10 @@ func TestElementParser(t *testing.T) {
 										From: Position{Index: 43, Line: 2, Col: 4},
 										To:   Position{Index: 48, Line: 2, Col: 9},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 50, Line: 2, Col: 11},
+									To:   Position{Index: 58, Line: 2, Col: 19},
 								},
 								Range: Range{
 									From: Position{Index: 43, Line: 2, Col: 4},
@@ -2012,6 +2156,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 0, Col: 12},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 14, Line: 0, Col: 14},
+							To:   Position{Index: 19, Line: 0, Col: 19},
+						},
 						Range: Range{
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 20, Line: 0, Col: 20},
@@ -2026,6 +2174,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 23, Line: 0, Col: 23},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 25, Line: 0, Col: 25},
+							To:   Position{Index: 30, Line: 0, Col: 30},
+						},
 						Range: Range{
 							From: Position{Index: 21, Line: 0, Col: 21},
 							To:   Position{Index: 31, Line: 0, Col: 31},
@@ -2039,6 +2191,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 32, Line: 0, Col: 32},
 								To:   Position{Index: 36, Line: 0, Col: 36},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 38, Line: 0, Col: 38},
+							To:   Position{Index: 43, Line: 0, Col: 43},
 						},
 						Range: Range{
 							From: Position{Index: 32, Line: 0, Col: 32},
@@ -2068,6 +2224,10 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
+						InitializerRange: Range{
+							From: Position{Index: 50, Line: 0, Col: 50},
+							To:   Position{Index: 90, Line: 0, Col: 90},
+						},
 						Range: Range{
 							From: Position{Index: 45, Line: 0, Col: 45},
 							To:   Position{Index: 90, Line: 0, Col: 90},
@@ -2082,6 +2242,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 102, Line: 0, Col: 102},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 104, Line: 0, Col: 104},
+							To:   Position{Index: 118, Line: 0, Col: 118},
+						},
 						Range: Range{
 							From: Position{Index: 91, Line: 0, Col: 91},
 							To:   Position{Index: 119, Line: 0, Col: 119},
@@ -2095,6 +2259,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 120, Line: 0, Col: 120},
 								To:   Position{Index: 132, Line: 0, Col: 132},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 134, Line: 0, Col: 134},
+							To:   Position{Index: 137, Line: 0, Col: 137},
 						},
 						Range: Range{
 							From: Position{Index: 120, Line: 0, Col: 120},
@@ -2132,6 +2300,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 1, Col: 5},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 14, Line: 1, Col: 7},
+							To:   Position{Index: 19, Line: 1, Col: 12},
+						},
 						Range: Range{
 							From: Position{Index: 8, Line: 1, Col: 1},
 							To:   Position{Index: 20, Line: 1, Col: 13},
@@ -2146,6 +2318,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 25, Line: 2, Col: 3},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 27, Line: 2, Col: 5},
+							To:   Position{Index: 32, Line: 2, Col: 10},
+						},
 						Range: Range{
 							From: Position{Index: 23, Line: 2, Col: 1},
 							To:   Position{Index: 33, Line: 2, Col: 11},
@@ -2159,6 +2335,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 36, Line: 3, Col: 1},
 								To:   Position{Index: 40, Line: 3, Col: 5},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 42, Line: 3, Col: 7},
+							To:   Position{Index: 47, Line: 3, Col: 12},
 						},
 						Range: Range{
 							From: Position{Index: 36, Line: 3, Col: 1},
@@ -2191,6 +2371,10 @@ func TestElementParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 12, Line: 0, Col: 12},
+							To:   Position{Index: 19, Line: 0, Col: 19},
+						},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 20, Line: 0, Col: 20},
@@ -2221,6 +2405,10 @@ func TestElementParser(t *testing.T) {
 								From: Position{Index: 4, Line: 0, Col: 4},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 12, Line: 0, Col: 12},
+							To:   Position{Index: 19, Line: 0, Col: 19},
 						},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
@@ -2262,6 +2450,10 @@ func TestElementParser(t *testing.T) {
 									Col:   52,
 								},
 							},
+						},
+						InitializerRange: Range{
+							From: Position{Index: 44, Line: 0, Col: 44},
+							To:   Position{Index: 54, Line: 0, Col: 54},
 						},
 						Range: Range{
 							From: Position{Index: 29, Line: 0, Col: 29},
@@ -2307,6 +2499,10 @@ func TestElementParser(t *testing.T) {
 									Col:   22,
 								},
 							},
+						},
+						InitializerRange: Range{
+							From: Position{Index: 12, Line: 0, Col: 12},
+							To:   Position{Index: 24, Line: 0, Col: 24},
 						},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -304,7 +304,7 @@ if test {` + " " + `
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 44, Line: 4, Col: 5},
 							To:   Position{Index: 56, Line: 4, Col: 17},
 						},
@@ -1172,7 +1172,7 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 7, Line: 0, Col: 7},
 							To:   Position{Index: 18, Line: 0, Col: 18},
 						},
@@ -1427,7 +1427,7 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 20, Line: 0, Col: 20},
 							To:   Position{Index: 52, Line: 0, Col: 52},
 						},
@@ -2224,7 +2224,7 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 50, Line: 0, Col: 50},
 							To:   Position{Index: 90, Line: 0, Col: 90},
 						},
@@ -2451,7 +2451,7 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 44, Line: 0, Col: 44},
 							To:   Position{Index: 54, Line: 0, Col: 54},
 						},
@@ -2500,7 +2500,7 @@ func TestElementParser(t *testing.T) {
 								},
 							},
 						},
-						InitializerRange: Range{
+						AttributeStartRange: Range{
 							From: Position{Index: 12, Line: 0, Col: 12},
 							To:   Position{Index: 24, Line: 0, Col: 24},
 						},

--- a/parser/v2/raw_test.go
+++ b/parser/v2/raw_test.go
@@ -33,6 +33,10 @@ func TestRawElementParser(t *testing.T) {
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 13, Line: 0, Col: 13},
+							To:   Position{Index: 21, Line: 0, Col: 21},
+						},
 						Range: Range{
 							From: Position{Index: 7, Line: 0, Col: 7},
 							To:   Position{Index: 22, Line: 0, Col: 22},
@@ -60,6 +64,10 @@ func TestRawElementParser(t *testing.T) {
 								From: Position{Index: 7, Line: 0, Col: 7},
 								To:   Position{Index: 11, Line: 0, Col: 11},
 							},
+						},
+						ValueRange: Range{
+							From: Position{Index: 13, Line: 0, Col: 13},
+							To:   Position{Index: 21, Line: 0, Col: 21},
 						},
 						Range: Range{
 							From: Position{Index: 7, Line: 0, Col: 7},

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -91,6 +91,10 @@ func TestScriptElementParser(t *testing.T) {
 								To:   Position{Index: 12, Line: 0, Col: 12},
 							},
 						},
+						ValueRange: Range{
+							From: Position{Index: 14, Line: 0, Col: 14},
+							To:   Position{Index: 22, Line: 0, Col: 22},
+						},
 						Range: Range{
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 23, Line: 0, Col: 23},
@@ -143,6 +147,10 @@ func TestScriptElementParser(t *testing.T) {
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
 					},
+					ValueRange: Range{
+						From: Position{Index: 14, Line: 0, Col: 14},
+						To:   Position{Index: 29, Line: 0, Col: 29},
+					},
 					Range: Range{
 						From: Position{Index: 8, Line: 0, Col: 8},
 						To:   Position{Index: 30, Line: 0, Col: 30},
@@ -181,6 +189,10 @@ func TestScriptElementParser(t *testing.T) {
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
 					},
+					ValueRange: Range{
+						From: Position{Index: 14, Line: 0, Col: 14},
+						To:   Position{Index: 20, Line: 0, Col: 20},
+					},
 					Range: Range{
 						From: Position{Index: 8, Line: 0, Col: 8},
 						To:   Position{Index: 21, Line: 0, Col: 21},
@@ -218,6 +230,10 @@ func TestScriptElementParser(t *testing.T) {
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+					},
+					ValueRange: Range{
+						From: Position{Index: 14, Line: 0, Col: 14},
+						To:   Position{Index: 24, Line: 0, Col: 24},
 					},
 					Range: Range{
 						From: Position{Index: 8, Line: 0, Col: 8},
@@ -448,6 +464,10 @@ set tier_1 to #tier-1's value
 							From: Position{Index: 8, Line: 0, Col: 8},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+					},
+					ValueRange: Range{
+						From: Position{Index: 14, Line: 0, Col: 14},
+						To:   Position{Index: 30, Line: 0, Col: 30},
 					},
 					Range: Range{
 						From: Position{Index: 8, Line: 0, Col: 8},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -607,6 +607,10 @@ func TestTemplateParser(t *testing.T) {
 										To:   Position{Index: 38, Line: 1, Col: 12},
 									},
 								},
+								ValueRange: Range{
+									From: Position{Index: 40, Line: 1, Col: 14},
+									To:   Position{Index: 44, Line: 1, Col: 18},
+								},
 								Range: Range{
 									From: Position{Index: 34, Line: 1, Col: 8},
 									To:   Position{Index: 45, Line: 1, Col: 19},
@@ -620,6 +624,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 46, Line: 1, Col: 20},
 										To:   Position{Index: 51, Line: 1, Col: 25},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 53, Line: 1, Col: 27},
+									To:   Position{Index: 54, Line: 1, Col: 28},
 								},
 								Range: Range{
 									From: Position{Index: 46, Line: 1, Col: 20},
@@ -649,6 +657,10 @@ func TestTemplateParser(t *testing.T) {
 										To:   Position{Index: 71, Line: 2, Col: 12},
 									},
 								},
+								ValueRange: Range{
+									From: Position{Index: 73, Line: 2, Col: 14},
+									To:   Position{Index: 77, Line: 2, Col: 18},
+								},
 								Range: Range{
 									From: Position{Index: 67, Line: 2, Col: 8},
 									To:   Position{Index: 78, Line: 2, Col: 19},
@@ -662,6 +674,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 79, Line: 2, Col: 20},
 										To:   Position{Index: 84, Line: 2, Col: 25},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 86, Line: 2, Col: 27},
+									To:   Position{Index: 87, Line: 2, Col: 28},
 								},
 								Range: Range{
 									From: Position{Index: 79, Line: 2, Col: 20},
@@ -791,6 +807,10 @@ func TestTemplateParser(t *testing.T) {
 										From: Position{Index: 16, Line: 1, Col: 4},
 										To:   Position{Index: 20, Line: 1, Col: 8},
 									},
+								},
+								ValueRange: Range{
+									From: Position{Index: 22, Line: 1, Col: 10},
+									To:   Position{Index: 23, Line: 1, Col: 11},
 								},
 								Range: Range{
 									From: Position{Index: 16, Line: 1, Col: 4},

--- a/parser/v2/templelementparser_test.go
+++ b/parser/v2/templelementparser_test.go
@@ -195,6 +195,10 @@ func TestTemplElementExpressionParser(t *testing.T) {
 										To:   Position{Index: 26, Line: 1, Col: 10},
 									},
 								},
+								ValueRange: Range{
+									From: Position{Index: 28, Line: 1, Col: 12},
+									To:   Position{Index: 35, Line: 1, Col: 19},
+								},
 								Range: Range{
 									From: Position{Index: 22, Line: 1, Col: 6},
 									To:   Position{Index: 36, Line: 1, Col: 20},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -890,6 +890,7 @@ func (bca *BoolConstantAttribute) Copy() Attribute {
 type ConstantAttribute struct {
 	Key         AttributeKey
 	Value       string
+	ValueRange  Range
 	SingleQuote bool
 	Range       Range
 }
@@ -913,6 +914,7 @@ func (ca *ConstantAttribute) Visit(v Visitor) error {
 func (ca *ConstantAttribute) Copy() Attribute {
 	return &ConstantAttribute{
 		Value:       ca.Value,
+		ValueRange:  ca.ValueRange,
 		SingleQuote: ca.SingleQuote,
 		Key:         ca.Key,
 		Range:       ca.Range,
@@ -948,9 +950,10 @@ func (bea *BoolExpressionAttribute) Copy() Attribute {
 
 // href={ ... }
 type ExpressionAttribute struct {
-	Key        AttributeKey
-	Expression Expression
-	Range      Range
+	Key              AttributeKey
+	Expression       Expression
+	InitializerRange Range
+	Range            Range
 }
 
 func (ea *ExpressionAttribute) String() string {
@@ -1011,9 +1014,10 @@ func (ea *ExpressionAttribute) Visit(v Visitor) error {
 
 func (ea *ExpressionAttribute) Copy() Attribute {
 	return &ExpressionAttribute{
-		Expression: ea.Expression,
-		Key:        ea.Key,
-		Range:      ea.Range,
+		Expression:       ea.Expression,
+		Key:              ea.Key,
+		InitializerRange: ea.InitializerRange,
+		Range:            ea.Range,
 	}
 }
 

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -950,10 +950,10 @@ func (bea *BoolExpressionAttribute) Copy() Attribute {
 
 // href={ ... }
 type ExpressionAttribute struct {
-	Key              AttributeKey
-	Expression       Expression
-	InitializerRange Range
-	Range            Range
+	Key                 AttributeKey
+	Expression          Expression
+	AttributeStartRange Range
+	Range               Range
 }
 
 func (ea *ExpressionAttribute) String() string {
@@ -1014,10 +1014,10 @@ func (ea *ExpressionAttribute) Visit(v Visitor) error {
 
 func (ea *ExpressionAttribute) Copy() Attribute {
 	return &ExpressionAttribute{
-		Expression:       ea.Expression,
-		Key:              ea.Key,
-		InitializerRange: ea.InitializerRange,
-		Range:            ea.Range,
+		Expression:          ea.Expression,
+		Key:                 ea.Key,
+		AttributeStartRange: ea.AttributeStartRange,
+		Range:               ea.Range,
 	}
 }
 


### PR DESCRIPTION
Adds a `ValueRange` to `ConstantAttribute`. In `href="test"`, it covers `test`.
Adds an `InitializerRange` to `ExpressionAttribute`. In `href={ user.URL }` it covers `={ user.URL }` (`ExpressionAttribute.Expression.Range` already covers `user.URL`).

Continues the initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302, #1335, #1336, #1337, #1338, #1340, #1341, #1347, #1348, and #1350.