### PR TITLE
feat: add experimental support for Go files

### DIFF
--- a/cmd/templ/lspcmd/lsp_test.go
+++ b/cmd/templ/lspcmd/lsp_test.go
@@ -539,19 +539,19 @@ func TestCodeAction(t *testing.T) {
 			replacement: `var s = Struct{}`,
 			cursor:      `              ^`,
 			assert: func(t *testing.T, actual []protocol.CodeAction) (msg string, ok bool) {
-				var expected []protocol.CodeAction
-				// To support code actions, update cmd/templ/lspcmd/proxy/server.go and add the
-				// Title (e.g. Organize Imports, or Fill Struct) to the supportedCodeActions map.
-
-				// Some Code Actions are simple edits, so all that is needed is for the server
-				// to remap the source code positions.
-
-				// However, other Code Actions are commands, where the arguments must be rewritten
-				// and will need to be handled individually.
-				if diff := lspdiff.CodeAction(expected, actual); diff != "" {
-					return fmt.Sprintf("unexpected codeAction: %v", diff), false
+				// Code actions with titles in the supportedCodeActions map
+				// are returned. Currently "Organize Imports" is supported.
+				for _, ca := range actual {
+					if ca.Title == "Organize Imports" {
+						return "", true
+					}
 				}
-				return "", true
+				// It's acceptable to get no code actions if gopls doesn't
+				// suggest any.
+				if len(actual) == 0 {
+					return "", true
+				}
+				return fmt.Sprintf("unexpected code actions: %v", actual), false
 			},
 		},
 	}

--- a/cmd/templ/lspcmd/proxy/client.go
+++ b/cmd/templ/lspcmd/proxy/client.go
@@ -59,14 +59,19 @@ func (p Client) PublishDiagnostics(ctx context.Context, params *lsp.PublishDiagn
 	for i, diagnostic := range params.Diagnostics {
 		p.Log.Info(fmt.Sprintf("client <- server: PublishDiagnostics: [%d]", i), slog.Any("diagnostic", diagnostic))
 	}
-	// Get the sourcemap from the cache.
-	uri := strings.TrimSuffix(string(params.URI), "_templ.go") + ".templ"
-	sourceMap, ok := p.SourceMapCache.Get(uri)
-	if !ok {
-		p.Log.Error("unable to complete because the sourcemap for the URI doesn't exist in the cache", slog.String("uri", uri))
-		return fmt.Errorf("unable to complete because the sourcemap for %q doesn't exist in the cache, has the didOpen notification been sent yet?", uri)
+	// Only convert diagnostics for _templ.go files. Diagnostics for regular
+	// .go files are dropped because the Go extension publishes those directly.
+	isTemplGoFile, templURI := convertTemplGoToTemplURI(params.URI)
+	if !isTemplGoFile {
+		return nil
 	}
-	params.URI = lsp.DocumentURI(uri)
+	// Get the sourcemap from the cache.
+	sourceMap, ok := p.SourceMapCache.Get(string(templURI))
+	if !ok {
+		p.Log.Error("unable to complete because the sourcemap for the URI doesn't exist in the cache", slog.String("uri", string(templURI)))
+		return fmt.Errorf("unable to complete because the sourcemap for %q doesn't exist in the cache, has the didOpen notification been sent yet?", templURI)
+	}
+	params.URI = templURI
 	// Rewrite the positions.
 	for i, item := range params.Diagnostics {
 		start, ok := sourceMap.SourcePositionFromTarget(item.Range.Start.Line, item.Range.Start.Character)
@@ -94,9 +99,8 @@ func (p Client) PublishDiagnostics(ctx context.Context, params *lsp.PublishDiagn
 		params.Diagnostics[i] = item
 		p.Log.Info(fmt.Sprintf("diagnostic [%d] rewritten", i), slog.Any("diagnostic", item))
 	}
-	params.Diagnostics = p.DiagnosticCache.AddTemplDiagnostics(uri, params.Diagnostics)
-	err = p.Target.PublishDiagnostics(ctx, params)
-	return err
+	params.Diagnostics = p.DiagnosticCache.AddTemplDiagnostics(string(templURI), params.Diagnostics)
+	return p.Target.PublishDiagnostics(ctx, params)
 }
 
 func (p Client) ShowMessage(ctx context.Context, params *lsp.ShowMessageParams) (err error) {
@@ -132,6 +136,7 @@ func (p Client) UnregisterCapability(ctx context.Context, params *lsp.Unregistra
 
 func (p Client) ApplyEdit(ctx context.Context, params *lsp.ApplyWorkspaceEditParams) (result *lsp.ApplyWorkspaceEditResponse, err error) {
 	p.Log.Info("client <- server: ApplyEdit")
+	convertWorkspaceEdit(p.SourceMapCache, p.Log, &params.Edit)
 	return p.Target.ApplyEdit(ctx, params)
 }
 

--- a/cmd/templ/lspcmd/proxy/client_test.go
+++ b/cmd/templ/lspcmd/proxy/client_test.go
@@ -1,0 +1,163 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	lsp "github.com/a-h/templ/lsp/protocol"
+)
+
+// mockClient records the parameters it receives.
+type mockClient struct {
+	applyEditParams         *lsp.ApplyWorkspaceEditParams
+	publishDiagnosticParams *lsp.PublishDiagnosticsParams
+}
+
+func (m *mockClient) ApplyEdit(ctx context.Context, params *lsp.ApplyWorkspaceEditParams) (*lsp.ApplyWorkspaceEditResponse, error) {
+	m.applyEditParams = params
+	return &lsp.ApplyWorkspaceEditResponse{Applied: true}, nil
+}
+
+func (m *mockClient) PublishDiagnostics(ctx context.Context, params *lsp.PublishDiagnosticsParams) error {
+	m.publishDiagnosticParams = params
+	return nil
+}
+
+func (m *mockClient) Progress(context.Context, *lsp.ProgressParams) error { return nil }
+func (m *mockClient) WorkDoneProgressCreate(context.Context, *lsp.WorkDoneProgressCreateParams) error {
+	return nil
+}
+func (m *mockClient) LogMessage(context.Context, *lsp.LogMessageParams) error   { return nil }
+func (m *mockClient) ShowMessage(context.Context, *lsp.ShowMessageParams) error { return nil }
+func (m *mockClient) ShowMessageRequest(context.Context, *lsp.ShowMessageRequestParams) (*lsp.MessageActionItem, error) {
+	return nil, nil
+}
+func (m *mockClient) Telemetry(context.Context, any) error                              { return nil }
+func (m *mockClient) RegisterCapability(context.Context, *lsp.RegistrationParams) error { return nil }
+func (m *mockClient) UnregisterCapability(context.Context, *lsp.UnregistrationParams) error {
+	return nil
+}
+func (m *mockClient) Configuration(context.Context, *lsp.ConfigurationParams) ([]any, error) {
+	return nil, nil
+}
+func (m *mockClient) WorkspaceFolders(context.Context) ([]lsp.WorkspaceFolder, error) {
+	return nil, nil
+}
+
+func TestApplyEditConvertsWorkspaceEdit(t *testing.T) {
+	mock := &mockClient{}
+	cache := NewSourceMapCache()
+	cache.Set("file:///project/component.templ", newTestSourceMap())
+	log := slog.Default()
+	client := Client{
+		Log:             log,
+		Target:          mock,
+		SourceMapCache:  cache,
+		DiagnosticCache: NewDiagnosticCache(),
+	}
+
+	_, err := client.ApplyEdit(context.Background(), &lsp.ApplyWorkspaceEditParams{
+		Edit: lsp.WorkspaceEdit{
+			DocumentChanges: []lsp.TextDocumentEdit{
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/component_templ.go"},
+					},
+					Edits: []lsp.TextEdit{{Range: goRange(), NewText: "newName"}},
+				},
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+					},
+					Edits: []lsp.TextEdit{{Range: lsp.Range{Start: lsp.Position{Line: 3, Character: 0}, End: lsp.Position{Line: 3, Character: 5}}, NewText: "newName"}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.applyEditParams == nil {
+		t.Fatal("expected ApplyEdit to be forwarded")
+	}
+	// The _templ.go document change should be converted.
+	if mock.applyEditParams.Edit.DocumentChanges[0].TextDocument.URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go URI to be converted, got %q", mock.applyEditParams.Edit.DocumentChanges[0].TextDocument.URI)
+	}
+	if diff := cmp.Diff(templRange(), mock.applyEditParams.Edit.DocumentChanges[0].Edits[0].Range); diff != "" {
+		t.Errorf("expected range to be converted (-want +got):\n%s", diff)
+	}
+	// The .go document change should be unchanged.
+	if mock.applyEditParams.Edit.DocumentChanges[1].TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected .go URI to be unchanged, got %q", mock.applyEditParams.Edit.DocumentChanges[1].TextDocument.URI)
+	}
+}
+
+func TestPublishDiagnosticsDropsGoFiles(t *testing.T) {
+	mock := &mockClient{}
+	cache := NewSourceMapCache()
+	log := slog.Default()
+	client := Client{
+		Log:             log,
+		Target:          mock,
+		SourceMapCache:  cache,
+		DiagnosticCache: NewDiagnosticCache(),
+	}
+
+	err := client.PublishDiagnostics(context.Background(), &lsp.PublishDiagnosticsParams{
+		URI: "file:///project/main.go",
+		Diagnostics: []lsp.Diagnostic{
+			{
+				Range:   lsp.Range{Start: lsp.Position{Line: 5, Character: 0}, End: lsp.Position{Line: 5, Character: 10}},
+				Message: "undefined variable",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Diagnostics for regular .go files should be dropped because the Go
+	// extension publishes those directly.
+	if mock.publishDiagnosticParams != nil {
+		t.Error("expected PublishDiagnostics to be dropped for .go files")
+	}
+}
+
+func TestPublishDiagnosticsConvertsTemplGoFiles(t *testing.T) {
+	mock := &mockClient{}
+	cache := NewSourceMapCache()
+	cache.Set("file:///project/component.templ", newTestSourceMap())
+	log := slog.Default()
+	client := Client{
+		Log:             log,
+		Target:          mock,
+		SourceMapCache:  cache,
+		DiagnosticCache: NewDiagnosticCache(),
+	}
+
+	err := client.PublishDiagnostics(context.Background(), &lsp.PublishDiagnosticsParams{
+		URI: "file:///project/component_templ.go",
+		Diagnostics: []lsp.Diagnostic{
+			{
+				Range:   lsp.Range{Start: lsp.Position{Line: 15, Character: 20}, End: lsp.Position{Line: 15, Character: 30}},
+				Message: "unused variable",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.publishDiagnosticParams == nil {
+		t.Fatal("expected PublishDiagnostics to be forwarded")
+	}
+	if mock.publishDiagnosticParams.URI != "file:///project/component.templ" {
+		t.Errorf("expected URI to be converted to .templ, got %q", mock.publishDiagnosticParams.URI)
+	}
+	diag := mock.publishDiagnosticParams.Diagnostics[0]
+	if diag.Range.Start.Line != 5 || diag.Range.Start.Character != 10 {
+		t.Errorf("expected diagnostic start to be converted to templ position, got %v", diag.Range.Start)
+	}
+}

--- a/cmd/templ/lspcmd/proxy/rewrite.go
+++ b/cmd/templ/lspcmd/proxy/rewrite.go
@@ -16,8 +16,8 @@ func convertTemplToGoURI(templURI lsp.DocumentURI) (isTemplFile bool, goURI lsp.
 	return true, lsp.DocumentURI(base + (strings.TrimSuffix(fileName, ".templ") + "_templ.go"))
 }
 
-// isNonTemplGoURI returns true if the URI refers to a .go file that is not a _templ.go file.
-func isNonTemplGoURI(docURI lsp.DocumentURI) bool {
+// isPlainGoFile returns true if the URI refers to a .go file that is not a _templ.go file.
+func isPlainGoFile(docURI lsp.DocumentURI) bool {
 	s := string(docURI)
 	return strings.HasSuffix(s, ".go") && !strings.HasSuffix(s, "_templ.go")
 }

--- a/cmd/templ/lspcmd/proxy/rewrite.go
+++ b/cmd/templ/lspcmd/proxy/rewrite.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"log/slog"
 	"path"
 	"strings"
 
@@ -15,10 +16,109 @@ func convertTemplToGoURI(templURI lsp.DocumentURI) (isTemplFile bool, goURI lsp.
 	return true, lsp.DocumentURI(base + (strings.TrimSuffix(fileName, ".templ") + "_templ.go"))
 }
 
+// isNonTemplGoURI returns true if the URI refers to a .go file that is not a _templ.go file.
+func isNonTemplGoURI(docURI lsp.DocumentURI) bool {
+	s := string(docURI)
+	return strings.HasSuffix(s, ".go") && !strings.HasSuffix(s, "_templ.go")
+}
+
 func convertTemplGoToTemplURI(goURI lsp.DocumentURI) (isTemplGoFile bool, templURI lsp.DocumentURI) {
 	base, fileName := path.Split(string(goURI))
 	if !strings.HasSuffix(fileName, "_templ.go") {
 		return
 	}
 	return true, lsp.DocumentURI(base + (strings.TrimSuffix(fileName, "_templ.go") + ".templ"))
+}
+
+// convertGoRangeToTemplRange converts a Go range to a templ range using the source map cache.
+func convertGoRangeToTemplRange(cache *SourceMapCache, log *slog.Logger, templURI lsp.DocumentURI, input lsp.Range) (output lsp.Range) {
+	output = input
+	sourceMap, ok := cache.Get(string(templURI))
+	if !ok {
+		log.Warn("go->templ: sourcemap not found in cache",
+			slog.String("uri", string(templURI)),
+			slog.Any("cachedURIs", cache.URIs()))
+		return
+	}
+	start, startMapped := sourceMap.SourcePositionFromTarget(input.Start.Line, input.Start.Character)
+	if startMapped {
+		output.Start.Line = start.Line
+		output.Start.Character = start.Col
+	}
+	end, endMapped := sourceMap.SourcePositionFromTarget(input.End.Line, input.End.Character)
+	if endMapped {
+		output.End.Line = end.Line
+		output.End.Character = end.Col
+	}
+	if !startMapped || !endMapped {
+		log.Warn("go->templ: range not found in sourcemap",
+			slog.String("uri", string(templURI)),
+			slog.Any("range", input),
+			slog.Bool("startMapped", startMapped),
+			slog.Bool("endMapped", endMapped))
+	}
+	return
+}
+
+// convertLocationResults converts _templ.go URIs and ranges in location results back to .templ URIs.
+func convertLocationResults(cache *SourceMapCache, log *slog.Logger, result []lsp.Location) {
+	for i, r := range result {
+		isTemplGoFile, templURI := convertTemplGoToTemplURI(r.URI)
+		if !isTemplGoFile {
+			continue
+		}
+		log.Info("convertLocationResults: converting",
+			slog.String("from", string(r.URI)),
+			slog.String("to", string(templURI)),
+			slog.Any("goRange", r.Range))
+		result[i].URI = templURI
+		result[i].Range = convertGoRangeToTemplRange(cache, log, templURI, r.Range)
+		log.Info("convertLocationResults: converted",
+			slog.Any("templRange", result[i].Range))
+	}
+}
+
+// convertCallHierarchyItem converts a _templ.go call hierarchy item back to .templ.
+func convertCallHierarchyItem(cache *SourceMapCache, log *slog.Logger, item *lsp.CallHierarchyItem) {
+	isTemplGoFile, templURI := convertTemplGoToTemplURI(item.URI)
+	if !isTemplGoFile {
+		return
+	}
+	item.URI = templURI
+	item.Range = convertGoRangeToTemplRange(cache, log, templURI, item.Range)
+	item.SelectionRange = convertGoRangeToTemplRange(cache, log, templURI, item.SelectionRange)
+}
+
+// convertWorkspaceEdit converts _templ.go URIs and ranges in a workspace edit back to .templ.
+func convertWorkspaceEdit(cache *SourceMapCache, log *slog.Logger, edit *lsp.WorkspaceEdit) {
+	if edit == nil {
+		return
+	}
+	for i, dc := range edit.DocumentChanges {
+		isTemplGoFile, templURI := convertTemplGoToTemplURI(dc.TextDocument.URI)
+		if !isTemplGoFile {
+			continue
+		}
+		for j, e := range dc.Edits {
+			dc.Edits[j].Range = convertGoRangeToTemplRange(cache, log, templURI, e.Range)
+		}
+		dc.TextDocument.URI = templURI
+		edit.DocumentChanges[i] = dc
+	}
+	if edit.Changes == nil {
+		return
+	}
+	converted := make(map[lsp.DocumentURI][]lsp.TextEdit)
+	for docURI, edits := range edit.Changes {
+		isTemplGoFile, templURI := convertTemplGoToTemplURI(docURI)
+		if !isTemplGoFile {
+			converted[docURI] = edits
+			continue
+		}
+		for i, e := range edits {
+			edits[i].Range = convertGoRangeToTemplRange(cache, log, templURI, e.Range)
+		}
+		converted[templURI] = edits
+	}
+	edit.Changes = converted
 }

--- a/cmd/templ/lspcmd/proxy/rewrite_test.go
+++ b/cmd/templ/lspcmd/proxy/rewrite_test.go
@@ -1,0 +1,257 @@
+package proxy
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/a-h/templ/parser/v2"
+	"github.com/google/go-cmp/cmp"
+
+	lsp "github.com/a-h/templ/lsp/protocol"
+)
+
+func TestConvertTemplToGoURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       lsp.DocumentURI
+		wantIsTempl bool
+		wantGoURI   lsp.DocumentURI
+	}{
+		{name: "templ file", input: "file:///tmp/test.templ", wantIsTempl: true, wantGoURI: "file:///tmp/test_templ.go"},
+		{name: "go file", input: "file:///tmp/test.go", wantIsTempl: false, wantGoURI: ""},
+		{name: "templ go file", input: "file:///tmp/test_templ.go", wantIsTempl: false, wantGoURI: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isTempl, goURI := convertTemplToGoURI(tt.input)
+			if isTempl != tt.wantIsTempl {
+				t.Errorf("isTemplFile: got %v, expected %v", isTempl, tt.wantIsTempl)
+			}
+			if isTempl && goURI != tt.wantGoURI {
+				t.Errorf("goURI: got %q, expected %q", goURI, tt.wantGoURI)
+			}
+		})
+	}
+}
+
+func TestConvertTemplGoToTemplURI(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         lsp.DocumentURI
+		wantIsTemplGo bool
+		wantTemplURI  lsp.DocumentURI
+	}{
+		{name: "templ go file", input: "file:///tmp/test_templ.go", wantIsTemplGo: true, wantTemplURI: "file:///tmp/test.templ"},
+		{name: "regular go file", input: "file:///tmp/test.go", wantIsTemplGo: false, wantTemplURI: ""},
+		{name: "templ file", input: "file:///tmp/test.templ", wantIsTemplGo: false, wantTemplURI: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isTemplGo, templURI := convertTemplGoToTemplURI(tt.input)
+			if isTemplGo != tt.wantIsTemplGo {
+				t.Errorf("isTemplGoFile: got %v, expected %v", isTemplGo, tt.wantIsTemplGo)
+			}
+			if isTemplGo && templURI != tt.wantTemplURI {
+				t.Errorf("templURI: got %q, expected %q", templURI, tt.wantTemplURI)
+			}
+		})
+	}
+}
+
+func newTestSourceMap() *parser.SourceMap {
+	sm := parser.NewSourceMap()
+	// Map templ line 5, col 10..20 -> Go line 15, col 20..30.
+	// The Value must be 10 characters to create per-character mappings.
+	sm.Add(
+		parser.Expression{
+			Value: "0123456789",
+			Range: parser.Range{
+				From: parser.Position{Index: 0, Line: 5, Col: 10},
+				To:   parser.Position{Index: 10, Line: 5, Col: 20},
+			},
+		},
+		parser.Range{
+			From: parser.Position{Index: 0, Line: 15, Col: 20},
+			To:   parser.Position{Index: 10, Line: 15, Col: 30},
+		},
+	)
+	return sm
+}
+
+func TestConvertLocationResults(t *testing.T) {
+	cache := NewSourceMapCache()
+	cache.Set("file:///tmp/test.templ", newTestSourceMap())
+	log := slog.Default()
+
+	tests := []struct {
+		name     string
+		input    []lsp.Location
+		expected []lsp.Location
+	}{
+		{
+			name: "converts templ go URI to templ URI",
+			input: []lsp.Location{
+				{
+					URI: "file:///tmp/test_templ.go",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 15, Character: 20},
+						End:   lsp.Position{Line: 15, Character: 30},
+					},
+				},
+			},
+			expected: []lsp.Location{
+				{
+					URI: "file:///tmp/test.templ",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 5, Character: 10},
+						End:   lsp.Position{Line: 5, Character: 20},
+					},
+				},
+			},
+		},
+		{
+			name: "leaves non-templ go URIs unchanged",
+			input: []lsp.Location{
+				{
+					URI: "file:///tmp/other.go",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 1, Character: 2},
+						End:   lsp.Position{Line: 3, Character: 4},
+					},
+				},
+			},
+			expected: []lsp.Location{
+				{
+					URI: "file:///tmp/other.go",
+					Range: lsp.Range{
+						Start: lsp.Position{Line: 1, Character: 2},
+						End:   lsp.Position{Line: 3, Character: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed results",
+			input: []lsp.Location{
+				{URI: "file:///tmp/other.go", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 2}, End: lsp.Position{Line: 3, Character: 4}}},
+				{URI: "file:///tmp/test_templ.go", Range: lsp.Range{Start: lsp.Position{Line: 15, Character: 20}, End: lsp.Position{Line: 15, Character: 30}}},
+			},
+			expected: []lsp.Location{
+				{URI: "file:///tmp/other.go", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 2}, End: lsp.Position{Line: 3, Character: 4}}},
+				{URI: "file:///tmp/test.templ", Range: lsp.Range{Start: lsp.Position{Line: 5, Character: 10}, End: lsp.Position{Line: 5, Character: 20}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertLocationResults(cache, log, tt.input)
+			if diff := cmp.Diff(tt.expected, tt.input); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertWorkspaceEdit(t *testing.T) {
+	cache := NewSourceMapCache()
+	cache.Set("file:///tmp/test.templ", newTestSourceMap())
+	log := slog.Default()
+
+	t.Run("nil edit", func(t *testing.T) {
+		convertWorkspaceEdit(cache, log, nil)
+	})
+	t.Run("converts DocumentChanges", func(t *testing.T) {
+		edit := &lsp.WorkspaceEdit{
+			DocumentChanges: []lsp.TextDocumentEdit{
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///tmp/test_templ.go"},
+					},
+					Edits: []lsp.TextEdit{
+						{
+							Range: lsp.Range{
+								Start: lsp.Position{Line: 15, Character: 20},
+								End:   lsp.Position{Line: 15, Character: 30},
+							},
+							NewText: "renamed",
+						},
+					},
+				},
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///tmp/other.go"},
+					},
+					Edits: []lsp.TextEdit{
+						{
+							Range: lsp.Range{
+								Start: lsp.Position{Line: 1, Character: 2},
+								End:   lsp.Position{Line: 3, Character: 4},
+							},
+							NewText: "unchanged",
+						},
+					},
+				},
+			},
+		}
+		convertWorkspaceEdit(cache, log, edit)
+		if edit.DocumentChanges[0].TextDocument.URI != "file:///tmp/test.templ" {
+			t.Errorf("expected URI to be converted, got %q", edit.DocumentChanges[0].TextDocument.URI)
+		}
+		expectedRange := lsp.Range{
+			Start: lsp.Position{Line: 5, Character: 10},
+			End:   lsp.Position{Line: 5, Character: 20},
+		}
+		if diff := cmp.Diff(expectedRange, edit.DocumentChanges[0].Edits[0].Range); diff != "" {
+			t.Errorf("unexpected range (-want +got):\n%s", diff)
+		}
+		if edit.DocumentChanges[1].TextDocument.URI != "file:///tmp/other.go" {
+			t.Errorf("expected non-templ URI to be unchanged, got %q", edit.DocumentChanges[1].TextDocument.URI)
+		}
+	})
+	t.Run("converts Changes map", func(t *testing.T) {
+		edit := &lsp.WorkspaceEdit{
+			Changes: map[lsp.DocumentURI][]lsp.TextEdit{
+				"file:///tmp/test_templ.go": {
+					{
+						Range: lsp.Range{
+							Start: lsp.Position{Line: 15, Character: 20},
+							End:   lsp.Position{Line: 15, Character: 30},
+						},
+						NewText: "renamed",
+					},
+				},
+				"file:///tmp/other.go": {
+					{
+						Range: lsp.Range{
+							Start: lsp.Position{Line: 1, Character: 2},
+							End:   lsp.Position{Line: 3, Character: 4},
+						},
+						NewText: "unchanged",
+					},
+				},
+			},
+		}
+		convertWorkspaceEdit(cache, log, edit)
+		if _, exists := edit.Changes["file:///tmp/test_templ.go"]; exists {
+			t.Error("expected _templ.go key to be removed from Changes map")
+		}
+		templEdits, exists := edit.Changes["file:///tmp/test.templ"]
+		if !exists {
+			t.Fatal("expected .templ key to be present in Changes map")
+		}
+		expectedRange := lsp.Range{
+			Start: lsp.Position{Line: 5, Character: 10},
+			End:   lsp.Position{Line: 5, Character: 20},
+		}
+		if diff := cmp.Diff(expectedRange, templEdits[0].Range); diff != "" {
+			t.Errorf("unexpected range (-want +got):\n%s", diff)
+		}
+		otherEdits, exists := edit.Changes["file:///tmp/other.go"]
+		if !exists {
+			t.Fatal("expected .go key to be preserved in Changes map")
+		}
+		if otherEdits[0].NewText != "unchanged" {
+			t.Errorf("expected non-templ edit to be unchanged")
+		}
+	})
+}

--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -418,7 +418,7 @@ func (p *Server) CodeAction(ctx context.Context, params *lsp.CodeActionParams) (
 			continue
 		}
 		for di, diag := range r.Diagnostics {
-			r.Diagnostics[di].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, diag.Range)
+			r.Diagnostics[di].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, diag.Range)
 		}
 		convertWorkspaceEdit(p.SourceMapCache, p.Log, r.Edit)
 		updatedResults = append(updatedResults, r)
@@ -447,7 +447,7 @@ func (p *Server) CodeLens(ctx context.Context, params *lsp.CodeLensParams) (resu
 		return
 	}
 	for i, cl := range result {
-		cl.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, cl.Range)
+		cl.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, cl.Range)
 		result[i] = cl
 	}
 	return
@@ -481,7 +481,7 @@ func (p *Server) ColorPresentation(ctx context.Context, params *lsp.ColorPresent
 	}
 	for i, r := range result {
 		if r.TextEdit != nil {
-			r.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.TextEdit.Range)
+			r.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r.TextEdit.Range)
 		}
 		result[i] = r
 	}
@@ -540,12 +540,12 @@ func (p *Server) Completion(ctx context.Context, params *lsp.CompletionParams) (
 		item.FilterText = stripTemplStringable(item.FilterText)
 		if item.TextEdit != nil {
 			if item.TextEdit.TextEdit != nil {
-				item.TextEdit.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.TextEdit.Range)
+				item.TextEdit.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, item.TextEdit.TextEdit.Range)
 				item.TextEdit.TextEdit.NewText = stripTemplStringable(item.TextEdit.TextEdit.NewText)
 			}
 			if item.TextEdit.InsertReplaceEdit != nil {
-				item.TextEdit.InsertReplaceEdit.Insert = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.InsertReplaceEdit.Insert)
-				item.TextEdit.InsertReplaceEdit.Replace = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.InsertReplaceEdit.Replace)
+				item.TextEdit.InsertReplaceEdit.Insert = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, item.TextEdit.InsertReplaceEdit.Insert)
+				item.TextEdit.InsertReplaceEdit.Replace = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, item.TextEdit.InsertReplaceEdit.Replace)
 				item.TextEdit.InsertReplaceEdit.NewText = stripTemplStringable(item.TextEdit.InsertReplaceEdit.NewText)
 			}
 		}
@@ -885,7 +885,7 @@ func (p *Server) DocumentColor(ctx context.Context, params *lsp.DocumentColorPar
 		return
 	}
 	for i, r := range result {
-		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r.Range)
 	}
 	return
 }
@@ -911,7 +911,7 @@ func (p *Server) DocumentHighlight(ctx context.Context, params *lsp.DocumentHigh
 	}
 	if isTempl {
 		for i, r := range result {
-			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r.Range)
 		}
 	}
 	return
@@ -953,7 +953,7 @@ func (p *Server) DocumentLinkResolve(ctx context.Context, params *lsp.DocumentLi
 		return
 	}
 	result.Target = templURI
-	result.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, result.Range)
+	result.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, result.Range)
 	return
 }
 
@@ -982,7 +982,7 @@ func (p *Server) DocumentSymbol(ctx context.Context, params *lsp.DocumentSymbolP
 		}
 		if s.SymbolInformation != nil {
 			s.SymbolInformation.Location.URI = templURI
-			s.SymbolInformation.Location.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, s.SymbolInformation.Location.Range)
+			s.SymbolInformation.Location.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, s.SymbolInformation.Location.Range)
 			result = append(result, s)
 		}
 	}
@@ -1013,7 +1013,7 @@ func (p *Server) convertSymbolRange(templURI lsp.DocumentURI, s *lsp.DocumentSym
 	}
 	// Within the symbol, we can select sub-sections.
 	// These are Go expressions, in the standard source map.
-	s.SelectionRange = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, s.SelectionRange)
+	s.SelectionRange = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, s.SelectionRange)
 	for i := range s.Children {
 		p.convertSymbolRange(templURI, &s.Children[i])
 		if !isRangeWithin(s.Range, s.Children[i].Range) {
@@ -1119,7 +1119,7 @@ func (p *Server) Hover(ctx context.Context, params *lsp.HoverParams) (result *ls
 		return
 	}
 	if result != nil && result.Range != nil && isTempl {
-		r := convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, *result.Range)
+		r := convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, *result.Range)
 		result.Range = &r
 	}
 	return
@@ -1165,7 +1165,7 @@ func (p *Server) OnTypeFormatting(ctx context.Context, params *lsp.DocumentOnTyp
 	}
 	if isTempl {
 		for i, r := range result {
-			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r.Range)
 		}
 	}
 	return
@@ -1188,7 +1188,7 @@ func (p *Server) PrepareRename(ctx context.Context, params *lsp.PrepareRenamePar
 		return
 	}
 	if isTempl {
-		output := convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, *result)
+		output := convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, *result)
 		return &output, nil
 	}
 	return
@@ -1212,7 +1212,7 @@ func (p *Server) RangeFormatting(ctx context.Context, params *lsp.DocumentRangeF
 		return
 	}
 	for i, r := range result {
-		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r.Range)
 	}
 	return
 }

--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -106,28 +106,28 @@ func (p *Server) convertTemplRangeToGoRange(templURI lsp.DocumentURI, input lsp.
 	return
 }
 
-func (p *Server) convertGoRangeToTemplRange(templURI lsp.DocumentURI, input lsp.Range) (output lsp.Range) {
-	output = input
-	sourceMap, ok := p.SourceMapCache.Get(string(templURI))
-	if !ok {
-		p.Log.Warn("go->templ: sourcemap not found in cache")
-		return
+// proxyPositionRequest determines how to forward a position-based request.
+// For .templ files, it converts the position to the corresponding Go position.
+// For non-templ files (e.g. .go), it returns the position unchanged so the
+// request can be forwarded to gopls as-is.
+// Returns ok=false only when position mapping fails for a .templ file.
+func (p *Server) proxyPositionRequest(templURI lsp.DocumentURI, pos lsp.Position) (isTempl bool, goURI lsp.DocumentURI, goPos lsp.Position, ok bool) {
+	isTemplFile, goFileURI := convertTemplToGoURI(templURI)
+	if !isTemplFile {
+		return false, templURI, pos, true
 	}
-	// Map from the source position to target Go position.
-	start, startPositionMapped := sourceMap.SourcePositionFromTarget(input.Start.Line, input.Start.Character)
-	if startPositionMapped {
-		output.Start.Line = start.Line
-		output.Start.Character = start.Col
+	sourceMap, smOk := p.SourceMapCache.Get(string(templURI))
+	if !smOk {
+		p.Log.Warn("proxyPositionRequest: sourcemap not found in cache", slog.String("uri", string(templURI)))
+		return true, templURI, pos, false
 	}
-	end, endPositionMapped := sourceMap.SourcePositionFromTarget(input.End.Line, input.End.Character)
-	if endPositionMapped {
-		output.End.Line = end.Line
-		output.End.Character = end.Col
+	to, toOk := sourceMap.TargetPositionFromSource(pos.Line, pos.Character)
+	if !toOk {
+		p.Log.Info("proxyPositionRequest: position not found in sourcemap",
+			slog.String("from", fmt.Sprintf("%d:%d", pos.Line, pos.Character)))
+		return true, templURI, pos, false
 	}
-	if !startPositionMapped || !endPositionMapped {
-		p.Log.Warn("go->templ: range not found in sourcemap", slog.Any("range", input))
-	}
-	return
+	return true, goFileURI, lsp.Position{Line: to.Line, Character: to.Col}, true
 }
 
 // parseTemplate parses the templ file content, and notifies the end user via the LSP about how it went.
@@ -256,6 +256,13 @@ func (p *Server) Initialize(ctx context.Context, params *lsp.InitializeParams) (
 
 	result.ServerInfo.Name = "templ-lsp"
 	result.ServerInfo.Version = templ.Version()
+	// Advertise Go file support so editors can register for .go files
+	// and route them through the proxy for cross-file navigation.
+	result.Capabilities.Experimental = map[string]any{
+		"templ": map[string]any{
+			"goFileSupport": true,
+		},
+	}
 
 	return result, err
 }
@@ -368,7 +375,9 @@ func (p *Server) SetTrace(ctx context.Context, params *lsp.SetTraceParams) (err 
 	return p.Target.SetTrace(ctx, params)
 }
 
-var supportedCodeActions = map[string]bool{}
+var supportedCodeActions = map[string]bool{
+	"Organize Imports": true,
+}
 
 func (p *Server) CodeAction(ctx context.Context, params *lsp.CodeActionParams) (result []lsp.CodeAction, err error) {
 	p.Log.Info("client -> server: CodeAction", slog.Any("params", params))
@@ -386,7 +395,7 @@ func (p *Server) CodeAction(ctx context.Context, params *lsp.CodeActionParams) (
 	}
 	isTemplFile, goURI := convertTemplToGoURI(templURI)
 	if !isTemplFile {
-		return p.Target.CodeAction(ctx, params)
+		return nil, nil
 	}
 	var ok bool
 	if params.Range, ok = p.convertTemplRangeToGoRange(templURI, params.Range); !ok {
@@ -408,20 +417,10 @@ func (p *Server) CodeAction(ctx context.Context, params *lsp.CodeActionParams) (
 		if !supportedCodeActions[r.Title] {
 			continue
 		}
-		// Rewrite the Diagnostics range field.
 		for di, diag := range r.Diagnostics {
-			r.Diagnostics[di].Range = p.convertGoRangeToTemplRange(templURI, diag.Range)
+			r.Diagnostics[di].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, diag.Range)
 		}
-		// Rewrite the DocumentChanges.
-		if r.Edit != nil {
-			for dci, dc := range r.Edit.DocumentChanges {
-				for ei, edit := range dc.Edits {
-					dc.Edits[ei].Range = p.convertGoRangeToTemplRange(templURI, edit.Range)
-				}
-				dc.TextDocument.URI = templURI
-				r.Edit.DocumentChanges[dci] = dc
-			}
-		}
+		convertWorkspaceEdit(p.SourceMapCache, p.Log, r.Edit)
 		updatedResults = append(updatedResults, r)
 	}
 	return updatedResults, nil
@@ -448,7 +447,7 @@ func (p *Server) CodeLens(ctx context.Context, params *lsp.CodeLensParams) (resu
 		return
 	}
 	for i, cl := range result {
-		cl.Range = p.convertGoRangeToTemplRange(templURI, cl.Range)
+		cl.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, cl.Range)
 		result[i] = cl
 	}
 	return
@@ -482,7 +481,7 @@ func (p *Server) ColorPresentation(ctx context.Context, params *lsp.ColorPresent
 	}
 	for i, r := range result {
 		if r.TextEdit != nil {
-			r.TextEdit.Range = p.convertGoRangeToTemplRange(templURI, r.TextEdit.Range)
+			r.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.TextEdit.Range)
 		}
 		result[i] = r
 	}
@@ -492,6 +491,10 @@ func (p *Server) ColorPresentation(ctx context.Context, params *lsp.ColorPresent
 func (p *Server) Completion(ctx context.Context, params *lsp.CompletionParams) (result *lsp.CompletionList, err error) {
 	p.Log.Info("client -> server: Completion")
 	defer p.Log.Info("client -> server: Completion end")
+	isTemplFile, _ := convertTemplToGoURI(params.TextDocument.URI)
+	if !isTemplFile {
+		return nil, nil
+	}
 	if params.Context != nil && params.Context.TriggerCharacter == "<" {
 		result = &lsp.CompletionList{
 			Items: htmlSnippets,
@@ -537,12 +540,12 @@ func (p *Server) Completion(ctx context.Context, params *lsp.CompletionParams) (
 		item.FilterText = stripTemplStringable(item.FilterText)
 		if item.TextEdit != nil {
 			if item.TextEdit.TextEdit != nil {
-				item.TextEdit.TextEdit.Range = p.convertGoRangeToTemplRange(templURI, item.TextEdit.TextEdit.Range)
+				item.TextEdit.TextEdit.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.TextEdit.Range)
 				item.TextEdit.TextEdit.NewText = stripTemplStringable(item.TextEdit.TextEdit.NewText)
 			}
 			if item.TextEdit.InsertReplaceEdit != nil {
-				item.TextEdit.InsertReplaceEdit.Insert = p.convertGoRangeToTemplRange(templURI, item.TextEdit.InsertReplaceEdit.Insert)
-				item.TextEdit.InsertReplaceEdit.Replace = p.convertGoRangeToTemplRange(templURI, item.TextEdit.InsertReplaceEdit.Replace)
+				item.TextEdit.InsertReplaceEdit.Insert = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.InsertReplaceEdit.Insert)
+				item.TextEdit.InsertReplaceEdit.Replace = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, item.TextEdit.InsertReplaceEdit.Replace)
 				item.TextEdit.InsertReplaceEdit.NewText = stripTemplStringable(item.TextEdit.InsertReplaceEdit.NewText)
 			}
 		}
@@ -641,62 +644,38 @@ func (p *Server) CompletionResolve(ctx context.Context, params *lsp.CompletionIt
 func (p *Server) Declaration(ctx context.Context, params *lsp.DeclarationParams) (result []lsp.Location /* Declaration | DeclarationLink[] | null */, err error) {
 	p.Log.Info("client -> server: Declaration")
 	defer p.Log.Info("client -> server: Declaration end")
-	// Rewrite the request.
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	// Call gopls and get the result.
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.Declaration(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	if result == nil {
-		return
-	}
-	for i, r := range result {
-		if isTemplGoFile, templURI := convertTemplGoToTemplURI(r.URI); isTemplGoFile {
-			result[i].URI = templURI
-			result[i].Range = p.convertGoRangeToTemplRange(templURI, r.Range)
-		}
-	}
+	convertLocationResults(p.SourceMapCache, p.Log, result)
 	return
 }
 
 func (p *Server) Definition(ctx context.Context, params *lsp.DefinitionParams) (result []lsp.Location /* Definition | DefinitionLink[] | null */, err error) {
 	p.Log.Info("client -> server: Definition")
 	defer p.Log.Info("client -> server: Definition end")
-	// Rewrite the request.
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
-		return result, nil
+		return nil, nil
 	}
-	// Call gopls and get the result.
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.Definition(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	if result == nil {
-		return
-	}
-	for i, r := range result {
-		if isTemplGoFile, templURI := convertTemplGoToTemplURI(r.URI); isTemplGoFile {
-			result[i].URI = templURI
-			result[i].Range = p.convertGoRangeToTemplRange(templURI, r.Range)
-		}
-	}
+	convertLocationResults(p.SourceMapCache, p.Log, result)
 	return
 }
 
@@ -710,8 +689,7 @@ func (p *Server) DidChange(ctx context.Context, params *lsp.DidChangeTextDocumen
 	}
 	isTemplFile, goURI := convertTemplToGoURI(templURI)
 	if !isTemplFile {
-		p.Log.Error("not a templ file")
-		return
+		return p.Target.DidChange(ctx, params)
 	}
 	// Apply content changes to the cached template.
 	d, err := p.TemplSource.Apply(string(templURI), params.ContentChanges)
@@ -791,9 +769,10 @@ func (p *Server) DidClose(ctx context.Context, params *lsp.DidCloseTextDocumentP
 			p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
 			return err
 		}
-
+		if isTemplFile, _ := convertTemplToGoURI(templURI); !isTemplFile {
+			return p.Target.DidClose(ctx, params)
+		}
 		params.TextDocument.URI = templURI
-
 		return p.templDocLazyLoader.Unload(ctx, params)
 	}
 
@@ -828,6 +807,9 @@ func (p *Server) DidOpen(ctx context.Context, params *lsp.DidOpenTextDocumentPar
 	defer p.Log.Info("client -> server: DidOpen end")
 
 	if p.NoPreload {
+		if isTemplFile, _ := convertTemplToGoURI(templURI); !isTemplFile {
+			return p.Target.DidOpen(ctx, params)
+		}
 		params.TextDocument.URI = templURI
 		return p.templDocLazyLoader.Load(ctx, params)
 	}
@@ -903,7 +885,7 @@ func (p *Server) DocumentColor(ctx context.Context, params *lsp.DocumentColorPar
 		return
 	}
 	for i, r := range result {
-		result[i].Range = p.convertGoRangeToTemplRange(templURI, r.Range)
+		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
 	}
 	return
 }
@@ -911,17 +893,37 @@ func (p *Server) DocumentColor(ctx context.Context, params *lsp.DocumentColorPar
 func (p *Server) DocumentHighlight(ctx context.Context, params *lsp.DocumentHighlightParams) (result []lsp.DocumentHighlight, err error) {
 	p.Log.Info("client -> server: DocumentHighlight")
 	defer p.Log.Info("client -> server: DocumentHighlight end")
+	if isNonTemplGoURI(params.TextDocument.URI) {
+		return nil, nil
+	}
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
+	if !ok {
+		return nil, nil
+	}
+	templURI := params.TextDocument.URI
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
+	result, err = p.Target.DocumentHighlight(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	if isTempl {
+		for i, r := range result {
+			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+		}
+	}
 	return
 }
 
 func (p *Server) DocumentLink(ctx context.Context, params *lsp.DocumentLinkParams) (result []lsp.DocumentLink, err error) {
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	p.Log.Info("client -> server: DocumentLink", slog.String("uri", string(templURI)))
+	p.Log.Info("client -> server: DocumentLink", slog.String("uri", string(params.TextDocument.URI)))
 	defer p.Log.Info("client -> server: DocumentLink end")
+	if isTemplFile, _ := convertTemplToGoURI(params.TextDocument.URI); !isTemplFile {
+		return nil, nil
+	}
+	// No document links for templ files.
 	return
 }
 
@@ -951,7 +953,7 @@ func (p *Server) DocumentLinkResolve(ctx context.Context, params *lsp.DocumentLi
 		return
 	}
 	result.Target = templURI
-	result.Range = p.convertGoRangeToTemplRange(templURI, result.Range)
+	result.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, result.Range)
 	return
 }
 
@@ -980,7 +982,7 @@ func (p *Server) DocumentSymbol(ctx context.Context, params *lsp.DocumentSymbolP
 		}
 		if s.SymbolInformation != nil {
 			s.SymbolInformation.Location.URI = templURI
-			s.SymbolInformation.Location.Range = p.convertGoRangeToTemplRange(templURI, s.SymbolInformation.Location.Range)
+			s.SymbolInformation.Location.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, s.SymbolInformation.Location.Range)
 			result = append(result, s)
 		}
 	}
@@ -1011,7 +1013,7 @@ func (p *Server) convertSymbolRange(templURI lsp.DocumentURI, s *lsp.DocumentSym
 	}
 	// Within the symbol, we can select sub-sections.
 	// These are Go expressions, in the standard source map.
-	s.SelectionRange = p.convertGoRangeToTemplRange(templURI, s.SelectionRange)
+	s.SelectionRange = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, s.SelectionRange)
 	for i := range s.Children {
 		p.convertSymbolRange(templURI, &s.Children[i])
 		if !isRangeWithin(s.Range, s.Children[i].Range) {
@@ -1045,14 +1047,19 @@ func (p *Server) ExecuteCommand(ctx context.Context, params *lsp.ExecuteCommandP
 func (p *Server) FoldingRanges(ctx context.Context, params *lsp.FoldingRangeParams) (result []lsp.FoldingRange, err error) {
 	p.Log.Info("client -> server: FoldingRanges")
 	defer p.Log.Info("client -> server: FoldingRanges end")
+	if isTemplFile, _ := convertTemplToGoURI(params.TextDocument.URI); !isTemplFile {
+		return nil, nil
+	}
 	// There are no folding ranges in templ files.
-	// return p.Target.FoldingRanges(ctx, params)
 	return []lsp.FoldingRange{}, nil
 }
 
 func (p *Server) Formatting(ctx context.Context, params *lsp.DocumentFormattingParams) (result []lsp.TextEdit, err error) {
 	p.Log.Info("client -> server: Formatting")
 	defer p.Log.Info("client -> server: Formatting end")
+	if isTemplFile, _ := convertTemplToGoURI(params.TextDocument.URI); !isTemplFile {
+		return nil, nil
+	}
 	// Format the current document.
 	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
 	if err != nil {
@@ -1095,27 +1102,24 @@ func (p *Server) Formatting(ctx context.Context, params *lsp.DocumentFormattingP
 func (p *Server) Hover(ctx context.Context, params *lsp.HoverParams) (result *lsp.Hover, err error) {
 	p.Log.Info("client -> server: Hover")
 	defer p.Log.Info("client -> server: Hover end")
-	// Rewrite the request.
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
+	if isNonTemplGoURI(params.TextDocument.URI) {
+		return nil, nil
 	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	// Call gopls.
+	templURI := params.TextDocument.URI
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.Hover(ctx, params)
 	if err != nil {
 		return
 	}
-	// Rewrite the response.
-	if result != nil && result.Range != nil {
-		p.Log.Info("hover: result returned")
-		r := p.convertGoRangeToTemplRange(templURI, *result.Range)
-		p.Log.Info("hover: setting range")
+	if result != nil && result.Range != nil && isTempl {
+		r := convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, *result.Range)
 		result.Range = &r
 	}
 	return
@@ -1124,59 +1128,45 @@ func (p *Server) Hover(ctx context.Context, params *lsp.HoverParams) (result *ls
 func (p *Server) Implementation(ctx context.Context, params *lsp.ImplementationParams) (result []lsp.Location, err error) {
 	p.Log.Info("client -> server: Implementation")
 	defer p.Log.Info("client -> server: Implementation end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	// Rewrite the request.
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.Implementation(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	if result == nil {
-		return
-	}
-	// Rewrite the response.
-	for i, r := range result {
-		r.URI = templURI
-		r.Range = p.convertGoRangeToTemplRange(templURI, r.Range)
-		result[i] = r
-	}
+	convertLocationResults(p.SourceMapCache, p.Log, result)
 	return
 }
 
 func (p *Server) OnTypeFormatting(ctx context.Context, params *lsp.DocumentOnTypeFormattingParams) (result []lsp.TextEdit, err error) {
 	p.Log.Info("client -> server: OnTypeFormatting")
 	defer p.Log.Info("client -> server: OnTypeFormatting end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
+	if isNonTemplGoURI(params.TextDocument.URI) {
+		return nil, nil
 	}
-	// Rewrite the request.
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	// Get the response.
+	templURI := params.TextDocument.URI
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.OnTypeFormatting(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	if result == nil {
-		return
-	}
-	// Rewrite the response.
-	for i, r := range result {
-		r.Range = p.convertGoRangeToTemplRange(templURI, r.Range)
-		result[i] = r
+	if isTempl {
+		for i, r := range result {
+			result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
+		}
 	}
 	return
 }
@@ -1184,108 +1174,100 @@ func (p *Server) OnTypeFormatting(ctx context.Context, params *lsp.DocumentOnTyp
 func (p *Server) PrepareRename(ctx context.Context, params *lsp.PrepareRenameParams) (result *lsp.Range, err error) {
 	p.Log.Info("client -> server: PrepareRename")
 	defer p.Log.Info("client -> server: PrepareRename end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	// Rewrite the request.
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	// Get the response.
+	templURI := params.TextDocument.URI
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.PrepareRename(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	if result == nil {
-		return
+	if isTempl {
+		output := convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, *result)
+		return &output, nil
 	}
-	// Rewrite the response.
-	output := p.convertGoRangeToTemplRange(templURI, *result)
-	return &output, nil
+	return
 }
 
 func (p *Server) RangeFormatting(ctx context.Context, params *lsp.DocumentRangeFormattingParams) (result []lsp.TextEdit, err error) {
 	p.Log.Info("client -> server: RangeFormatting")
 	defer p.Log.Info("client -> server: RangeFormatting end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
+	templURI := params.TextDocument.URI
+	isTemplFile, goURI := convertTemplToGoURI(templURI)
+	if !isTemplFile {
+		return nil, nil
+	}
+	var ok bool
+	if params.Range, ok = p.convertTemplRangeToGoRange(templURI, params.Range); !ok {
 		return
 	}
-	// Rewrite the request.
-	var isTemplURI bool
-	isTemplURI, params.TextDocument.URI = convertTemplToGoURI(templURI)
-	if !isTemplURI {
-		err = fmt.Errorf("not a templ file")
-		return
-	}
-	// Call gopls.
+	params.TextDocument.URI = goURI
 	result, err = p.Target.RangeFormatting(ctx, params)
 	if err != nil {
 		return
 	}
-	// Rewrite the response.
 	for i, r := range result {
-		r.Range = p.convertGoRangeToTemplRange(templURI, r.Range)
-		result[i] = r
+		result[i].Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log,templURI, r.Range)
 	}
-	return result, err
+	return
 }
 
 func (p *Server) References(ctx context.Context, params *lsp.ReferenceParams) (result []lsp.Location, err error) {
 	p.Log.Info("client -> server: References")
 	defer p.Log.Info("client -> server: References end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	// Rewrite the request.
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	// Call gopls.
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
 	result, err = p.Target.References(ctx, params)
-	if err != nil {
+	if err != nil || result == nil {
 		return
 	}
-	// Rewrite the response.
-	for i, r := range result {
-		isTemplURI, templURI := convertTemplGoToTemplURI(r.URI)
-		if isTemplURI {
-			p.Log.Info(fmt.Sprintf("references-%d - range conversion for %s", i, r.URI))
-			r.URI, r.Range = templURI, p.convertGoRangeToTemplRange(templURI, r.Range)
-		}
-		p.Log.Info(fmt.Sprintf("references-%d: %+v", i, r))
-		result[i] = r
-	}
-	return result, err
+	convertLocationResults(p.SourceMapCache, p.Log, result)
+	return
 }
 
 func (p *Server) Rename(ctx context.Context, params *lsp.RenameParams) (result *lsp.WorkspaceEdit, err error) {
 	p.Log.Info("client -> server: Rename")
 	defer p.Log.Info("client -> server: Rename end")
-	return p.Target.Rename(ctx, params)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
+	if !ok {
+		return nil, nil
+	}
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
+	result, err = p.Target.Rename(ctx, params)
+	if err != nil {
+		return
+	}
+	convertWorkspaceEdit(p.SourceMapCache, p.Log, result)
+	return
 }
 
 func (p *Server) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpParams) (result *lsp.SignatureHelp, err error) {
 	p.Log.Info("client -> server: SignatureHelp")
 	defer p.Log.Info("client -> server: SignatureHelp end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
+	if isNonTemplGoURI(params.TextDocument.URI) {
+		return nil, nil
 	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
+	}
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
 	}
 	return p.Target.SignatureHelp(ctx, params)
 }
@@ -1293,33 +1275,43 @@ func (p *Server) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpPar
 func (p *Server) Symbols(ctx context.Context, params *lsp.WorkspaceSymbolParams) (result []lsp.SymbolInformation, err error) {
 	p.Log.Info("client -> server: Symbols")
 	defer p.Log.Info("client -> server: Symbols end")
-	return p.Target.Symbols(ctx, params)
+	result, err = p.Target.Symbols(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	for i, s := range result {
+		if isTemplGoFile, templURI := convertTemplGoToTemplURI(s.Location.URI); isTemplGoFile {
+			result[i].Location.URI = templURI
+			result[i].Location.Range = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, s.Location.Range)
+		}
+	}
+	return
 }
 
 func (p *Server) TypeDefinition(ctx context.Context, params *lsp.TypeDefinitionParams) (result []lsp.Location, err error) {
 	p.Log.Info("client -> server: TypeDefinition")
 	defer p.Log.Info("client -> server: TypeDefinition end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
-	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
 	}
-	return p.Target.TypeDefinition(ctx, params)
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
+	result, err = p.Target.TypeDefinition(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	convertLocationResults(p.SourceMapCache, p.Log, result)
+	return
 }
 
 func (p *Server) WillSave(ctx context.Context, params *lsp.WillSaveTextDocumentParams) (err error) {
 	p.Log.Info("client -> server: WillSave")
 	defer p.Log.Info("client -> server: WillSave end")
-	var ok bool
-	ok, params.TextDocument.URI = convertTemplToGoURI(params.TextDocument.URI)
-	if !ok {
-		p.Log.Error("not a templ file")
-		return nil
+	if isTemplFile, goURI := convertTemplToGoURI(params.TextDocument.URI); isTemplFile {
+		params.TextDocument.URI = goURI
 	}
 	return p.Target.WillSave(ctx, params)
 }
@@ -1381,19 +1373,55 @@ func (p *Server) CodeLensRefresh(ctx context.Context) (err error) {
 func (p *Server) PrepareCallHierarchy(ctx context.Context, params *lsp.CallHierarchyPrepareParams) (result []lsp.CallHierarchyItem, err error) {
 	p.Log.Info("client -> server: PrepareCallHierarchy")
 	defer p.Log.Info("client -> server: PrepareCallHierarchy end")
-	return p.Target.PrepareCallHierarchy(ctx, params)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
+	if !ok {
+		return nil, nil
+	}
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
+	}
+	result, err = p.Target.PrepareCallHierarchy(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	for i := range result {
+		convertCallHierarchyItem(p.SourceMapCache, p.Log, &result[i])
+	}
+	return
 }
 
 func (p *Server) IncomingCalls(ctx context.Context, params *lsp.CallHierarchyIncomingCallsParams) (result []lsp.CallHierarchyIncomingCall, err error) {
 	p.Log.Info("client -> server: IncomingCalls")
 	defer p.Log.Info("client -> server: IncomingCalls end")
-	return p.Target.IncomingCalls(ctx, params)
+	result, err = p.Target.IncomingCalls(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	for i := range result {
+		// Check the original URI before converting the item.
+		isTemplGoFile, templURI := convertTemplGoToTemplURI(result[i].From.URI)
+		convertCallHierarchyItem(p.SourceMapCache, p.Log, &result[i].From)
+		if isTemplGoFile {
+			for j, r := range result[i].FromRanges {
+				result[i].FromRanges[j] = convertGoRangeToTemplRange(p.SourceMapCache, p.Log, templURI, r)
+			}
+		}
+	}
+	return
 }
 
 func (p *Server) OutgoingCalls(ctx context.Context, params *lsp.CallHierarchyOutgoingCallsParams) (result []lsp.CallHierarchyOutgoingCall, err error) {
 	p.Log.Info("client -> server: OutgoingCalls")
 	defer p.Log.Info("client -> server: OutgoingCalls end")
-	return p.Target.OutgoingCalls(ctx, params)
+	result, err = p.Target.OutgoingCalls(ctx, params)
+	if err != nil || result == nil {
+		return
+	}
+	for i := range result {
+		convertCallHierarchyItem(p.SourceMapCache, p.Log, &result[i].To)
+	}
+	return
 }
 
 func (p *Server) SemanticTokensFull(ctx context.Context, params *lsp.SemanticTokensParams) (result *lsp.SemanticTokens, err error) {
@@ -1444,15 +1472,16 @@ func (p *Server) LinkedEditingRange(ctx context.Context, params *lsp.LinkedEditi
 func (p *Server) Moniker(ctx context.Context, params *lsp.MonikerParams) (result []lsp.Moniker, err error) {
 	p.Log.Info("client -> server: Moniker")
 	defer p.Log.Info("client -> server: Moniker end")
-	templURI, err := uri.ParseDocumentURI(string(params.TextDocument.URI))
-	if err != nil {
-		p.Log.Error("invalid uri", slog.String("uri", string(params.TextDocument.URI)))
-		return
+	if isNonTemplGoURI(params.TextDocument.URI) {
+		return nil, nil
 	}
-	var ok bool
-	ok, params.TextDocument.URI, params.Position = p.updatePosition(templURI, params.Position)
+	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
 	if !ok {
 		return nil, nil
+	}
+	if isTempl {
+		params.TextDocument.URI = goURI
+		params.Position = goPos
 	}
 	return p.Target.Moniker(ctx, params)
 }

--- a/cmd/templ/lspcmd/proxy/server.go
+++ b/cmd/templ/lspcmd/proxy/server.go
@@ -893,7 +893,7 @@ func (p *Server) DocumentColor(ctx context.Context, params *lsp.DocumentColorPar
 func (p *Server) DocumentHighlight(ctx context.Context, params *lsp.DocumentHighlightParams) (result []lsp.DocumentHighlight, err error) {
 	p.Log.Info("client -> server: DocumentHighlight")
 	defer p.Log.Info("client -> server: DocumentHighlight end")
-	if isNonTemplGoURI(params.TextDocument.URI) {
+	if isPlainGoFile(params.TextDocument.URI) {
 		return nil, nil
 	}
 	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
@@ -1047,9 +1047,6 @@ func (p *Server) ExecuteCommand(ctx context.Context, params *lsp.ExecuteCommandP
 func (p *Server) FoldingRanges(ctx context.Context, params *lsp.FoldingRangeParams) (result []lsp.FoldingRange, err error) {
 	p.Log.Info("client -> server: FoldingRanges")
 	defer p.Log.Info("client -> server: FoldingRanges end")
-	if isTemplFile, _ := convertTemplToGoURI(params.TextDocument.URI); !isTemplFile {
-		return nil, nil
-	}
 	// There are no folding ranges in templ files.
 	return []lsp.FoldingRange{}, nil
 }
@@ -1102,7 +1099,7 @@ func (p *Server) Formatting(ctx context.Context, params *lsp.DocumentFormattingP
 func (p *Server) Hover(ctx context.Context, params *lsp.HoverParams) (result *lsp.Hover, err error) {
 	p.Log.Info("client -> server: Hover")
 	defer p.Log.Info("client -> server: Hover end")
-	if isNonTemplGoURI(params.TextDocument.URI) {
+	if isPlainGoFile(params.TextDocument.URI) {
 		return nil, nil
 	}
 	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
@@ -1147,7 +1144,7 @@ func (p *Server) Implementation(ctx context.Context, params *lsp.ImplementationP
 func (p *Server) OnTypeFormatting(ctx context.Context, params *lsp.DocumentOnTypeFormattingParams) (result []lsp.TextEdit, err error) {
 	p.Log.Info("client -> server: OnTypeFormatting")
 	defer p.Log.Info("client -> server: OnTypeFormatting end")
-	if isNonTemplGoURI(params.TextDocument.URI) {
+	if isPlainGoFile(params.TextDocument.URI) {
 		return nil, nil
 	}
 	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
@@ -1258,7 +1255,7 @@ func (p *Server) Rename(ctx context.Context, params *lsp.RenameParams) (result *
 func (p *Server) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpParams) (result *lsp.SignatureHelp, err error) {
 	p.Log.Info("client -> server: SignatureHelp")
 	defer p.Log.Info("client -> server: SignatureHelp end")
-	if isNonTemplGoURI(params.TextDocument.URI) {
+	if isPlainGoFile(params.TextDocument.URI) {
 		return nil, nil
 	}
 	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)
@@ -1472,7 +1469,7 @@ func (p *Server) LinkedEditingRange(ctx context.Context, params *lsp.LinkedEditi
 func (p *Server) Moniker(ctx context.Context, params *lsp.MonikerParams) (result []lsp.Moniker, err error) {
 	p.Log.Info("client -> server: Moniker")
 	defer p.Log.Info("client -> server: Moniker end")
-	if isNonTemplGoURI(params.TextDocument.URI) {
+	if isPlainGoFile(params.TextDocument.URI) {
 		return nil, nil
 	}
 	isTempl, goURI, goPos, ok := p.proxyPositionRequest(params.TextDocument.URI, params.Position)

--- a/cmd/templ/lspcmd/proxy/server_test.go
+++ b/cmd/templ/lspcmd/proxy/server_test.go
@@ -40,6 +40,8 @@ type mockServer struct {
 	symbolsParams              *lsp.WorkspaceSymbolParams
 	signatureHelpParams        *lsp.SignatureHelpParams
 	codeActionParams           *lsp.CodeActionParams
+	onTypeFormattingParams     *lsp.DocumentOnTypeFormattingParams
+	monikerParams              *lsp.MonikerParams
 
 	// Return values.
 	definitionResult           []lsp.Location
@@ -240,7 +242,8 @@ func (m *mockServer) DocumentSymbol(context.Context, *lsp.DocumentSymbolParams) 
 func (m *mockServer) ExecuteCommand(context.Context, *lsp.ExecuteCommandParams) (any, error) {
 	return nil, nil
 }
-func (m *mockServer) OnTypeFormatting(context.Context, *lsp.DocumentOnTypeFormattingParams) ([]lsp.TextEdit, error) {
+func (m *mockServer) OnTypeFormatting(ctx context.Context, params *lsp.DocumentOnTypeFormattingParams) ([]lsp.TextEdit, error) {
+	m.onTypeFormattingParams = params
 	return nil, nil
 }
 func (m *mockServer) WillSaveWaitUntil(context.Context, *lsp.WillSaveTextDocumentParams) ([]lsp.TextEdit, error) {
@@ -272,7 +275,8 @@ func (m *mockServer) SemanticTokensRefresh(context.Context) error { return nil }
 func (m *mockServer) LinkedEditingRange(context.Context, *lsp.LinkedEditingRangeParams) (*lsp.LinkedEditingRanges, error) {
 	return nil, nil
 }
-func (m *mockServer) Moniker(context.Context, *lsp.MonikerParams) ([]lsp.Moniker, error) {
+func (m *mockServer) Moniker(ctx context.Context, params *lsp.MonikerParams) ([]lsp.Moniker, error) {
+	m.monikerParams = params
 	return nil, nil
 }
 func (m *mockServer) Request(context.Context, string, any) (any, error) { return nil, nil }
@@ -618,25 +622,6 @@ func TestWillSaveForwardsGoFiles(t *testing.T) {
 	}
 }
 
-func TestFoldingRangesDropsGoFiles(t *testing.T) {
-	mock := &mockServer{}
-	s := newTestServer(mock)
-	result, err := s.FoldingRanges(context.Background(), &lsp.FoldingRangeParams{
-		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
-			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if mock.foldingRangesParams != nil {
-		t.Error("expected FoldingRanges to not be forwarded for .go files")
-	}
-	if result != nil {
-		t.Errorf("expected nil result for .go files, got %v", result)
-	}
-}
-
 func TestFoldingRangesReturnsEmptyForTemplFiles(t *testing.T) {
 	mock := &mockServer{}
 	s := newTestServer(mock)
@@ -926,6 +911,67 @@ func TestSignatureHelpDropsGoFiles(t *testing.T) {
 	}
 	if mock.signatureHelpParams != nil {
 		t.Error("expected SignatureHelp to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestHoverDropsGoFiles(t *testing.T) {
+	mock := &mockServer{
+		hoverResult: &lsp.Hover{},
+	}
+	s := newTestServer(mock)
+	result, err := s.Hover(context.Background(), &lsp.HoverParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.hoverParams != nil {
+		t.Error("expected Hover to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestOnTypeFormattingDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.OnTypeFormatting(context.Background(), &lsp.DocumentOnTypeFormattingParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+		Position:     lsp.Position{Line: 10, Character: 5},
+		Ch:           "}",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.onTypeFormattingParams != nil {
+		t.Error("expected OnTypeFormatting to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestMonikerDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.Moniker(context.Background(), &lsp.MonikerParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.monikerParams != nil {
+		t.Error("expected Moniker to not be forwarded for .go files")
 	}
 	if result != nil {
 		t.Errorf("expected nil result for .go files, got %v", result)

--- a/cmd/templ/lspcmd/proxy/server_test.go
+++ b/cmd/templ/lspcmd/proxy/server_test.go
@@ -1,0 +1,1029 @@
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/a-h/templ/parser/v2"
+	"github.com/google/go-cmp/cmp"
+
+	lsp "github.com/a-h/templ/lsp/protocol"
+)
+
+// mockServer records the parameters it receives and returns preconfigured results.
+// Only methods under test are implemented; the rest panic.
+type mockServer struct {
+	// Recorded params from the most recent call.
+	definitionParams           *lsp.DefinitionParams
+	declarationParams          *lsp.DeclarationParams
+	referencesParams           *lsp.ReferenceParams
+	renameParams               *lsp.RenameParams
+	typeDefinitionParams       *lsp.TypeDefinitionParams
+	implementationParams       *lsp.ImplementationParams
+	hoverParams                *lsp.HoverParams
+	documentHighlightParams    *lsp.DocumentHighlightParams
+	prepareRenameParams        *lsp.PrepareRenameParams
+	completionParams           *lsp.CompletionParams
+	didChangeParams            *lsp.DidChangeTextDocumentParams
+	didOpenParams              *lsp.DidOpenTextDocumentParams
+	didCloseParams             *lsp.DidCloseTextDocumentParams
+	willSaveParams             *lsp.WillSaveTextDocumentParams
+	foldingRangesParams        *lsp.FoldingRangeParams
+	formattingParams           *lsp.DocumentFormattingParams
+	rangeFormattingParams      *lsp.DocumentRangeFormattingParams
+	semanticTokensFullParams   *lsp.SemanticTokensParams
+	documentLinkParams         *lsp.DocumentLinkParams
+	prepareCallHierarchyParams *lsp.CallHierarchyPrepareParams
+	incomingCallsParams        *lsp.CallHierarchyIncomingCallsParams
+	outgoingCallsParams        *lsp.CallHierarchyOutgoingCallsParams
+	symbolsParams              *lsp.WorkspaceSymbolParams
+	signatureHelpParams        *lsp.SignatureHelpParams
+	codeActionParams           *lsp.CodeActionParams
+
+	// Return values.
+	definitionResult           []lsp.Location
+	declarationResult          []lsp.Location
+	referencesResult           []lsp.Location
+	renameResult               *lsp.WorkspaceEdit
+	typeDefinitionResult       []lsp.Location
+	implementationResult       []lsp.Location
+	hoverResult                *lsp.Hover
+	documentHighlightResult    []lsp.DocumentHighlight
+	prepareRenameResult        *lsp.Range
+	completionResult           *lsp.CompletionList
+	foldingRangesResult        []lsp.FoldingRange
+	formattingResult           []lsp.TextEdit
+	rangeFormattingResult      []lsp.TextEdit
+	semanticTokensFullResult   *lsp.SemanticTokens
+	documentLinkResult         []lsp.DocumentLink
+	prepareCallHierarchyResult []lsp.CallHierarchyItem
+	incomingCallsResult        []lsp.CallHierarchyIncomingCall
+	outgoingCallsResult        []lsp.CallHierarchyOutgoingCall
+	symbolsResult              []lsp.SymbolInformation
+	signatureHelpResult        *lsp.SignatureHelp
+	codeActionResult           []lsp.CodeAction
+}
+
+func (m *mockServer) Definition(ctx context.Context, params *lsp.DefinitionParams) ([]lsp.Location, error) {
+	m.definitionParams = params
+	return m.definitionResult, nil
+}
+
+func (m *mockServer) Declaration(ctx context.Context, params *lsp.DeclarationParams) ([]lsp.Location, error) {
+	m.declarationParams = params
+	return m.declarationResult, nil
+}
+
+func (m *mockServer) References(ctx context.Context, params *lsp.ReferenceParams) ([]lsp.Location, error) {
+	m.referencesParams = params
+	return m.referencesResult, nil
+}
+
+func (m *mockServer) Rename(ctx context.Context, params *lsp.RenameParams) (*lsp.WorkspaceEdit, error) {
+	m.renameParams = params
+	return m.renameResult, nil
+}
+
+func (m *mockServer) TypeDefinition(ctx context.Context, params *lsp.TypeDefinitionParams) ([]lsp.Location, error) {
+	m.typeDefinitionParams = params
+	return m.typeDefinitionResult, nil
+}
+
+func (m *mockServer) Implementation(ctx context.Context, params *lsp.ImplementationParams) ([]lsp.Location, error) {
+	m.implementationParams = params
+	return m.implementationResult, nil
+}
+
+func (m *mockServer) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.Hover, error) {
+	m.hoverParams = params
+	return m.hoverResult, nil
+}
+
+func (m *mockServer) DocumentHighlight(ctx context.Context, params *lsp.DocumentHighlightParams) ([]lsp.DocumentHighlight, error) {
+	m.documentHighlightParams = params
+	return m.documentHighlightResult, nil
+}
+
+func (m *mockServer) PrepareRename(ctx context.Context, params *lsp.PrepareRenameParams) (*lsp.Range, error) {
+	m.prepareRenameParams = params
+	return m.prepareRenameResult, nil
+}
+
+func (m *mockServer) Completion(ctx context.Context, params *lsp.CompletionParams) (*lsp.CompletionList, error) {
+	m.completionParams = params
+	return m.completionResult, nil
+}
+
+func (m *mockServer) DidChange(ctx context.Context, params *lsp.DidChangeTextDocumentParams) error {
+	m.didChangeParams = params
+	return nil
+}
+
+func (m *mockServer) DidOpen(ctx context.Context, params *lsp.DidOpenTextDocumentParams) error {
+	m.didOpenParams = params
+	return nil
+}
+
+func (m *mockServer) DidClose(ctx context.Context, params *lsp.DidCloseTextDocumentParams) error {
+	m.didCloseParams = params
+	return nil
+}
+
+func (m *mockServer) WillSave(ctx context.Context, params *lsp.WillSaveTextDocumentParams) error {
+	m.willSaveParams = params
+	return nil
+}
+
+func (m *mockServer) FoldingRanges(ctx context.Context, params *lsp.FoldingRangeParams) ([]lsp.FoldingRange, error) {
+	m.foldingRangesParams = params
+	return m.foldingRangesResult, nil
+}
+
+func (m *mockServer) Formatting(ctx context.Context, params *lsp.DocumentFormattingParams) ([]lsp.TextEdit, error) {
+	m.formattingParams = params
+	return m.formattingResult, nil
+}
+
+func (m *mockServer) RangeFormatting(ctx context.Context, params *lsp.DocumentRangeFormattingParams) ([]lsp.TextEdit, error) {
+	m.rangeFormattingParams = params
+	return m.rangeFormattingResult, nil
+}
+
+func (m *mockServer) SemanticTokensFull(ctx context.Context, params *lsp.SemanticTokensParams) (*lsp.SemanticTokens, error) {
+	m.semanticTokensFullParams = params
+	return m.semanticTokensFullResult, nil
+}
+
+func (m *mockServer) DocumentLink(ctx context.Context, params *lsp.DocumentLinkParams) ([]lsp.DocumentLink, error) {
+	m.documentLinkParams = params
+	return m.documentLinkResult, nil
+}
+
+func (m *mockServer) PrepareCallHierarchy(ctx context.Context, params *lsp.CallHierarchyPrepareParams) ([]lsp.CallHierarchyItem, error) {
+	m.prepareCallHierarchyParams = params
+	return m.prepareCallHierarchyResult, nil
+}
+
+func (m *mockServer) IncomingCalls(ctx context.Context, params *lsp.CallHierarchyIncomingCallsParams) ([]lsp.CallHierarchyIncomingCall, error) {
+	m.incomingCallsParams = params
+	return m.incomingCallsResult, nil
+}
+
+func (m *mockServer) OutgoingCalls(ctx context.Context, params *lsp.CallHierarchyOutgoingCallsParams) ([]lsp.CallHierarchyOutgoingCall, error) {
+	m.outgoingCallsParams = params
+	return m.outgoingCallsResult, nil
+}
+
+func (m *mockServer) Symbols(ctx context.Context, params *lsp.WorkspaceSymbolParams) ([]lsp.SymbolInformation, error) {
+	m.symbolsParams = params
+	return m.symbolsResult, nil
+}
+
+func (m *mockServer) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpParams) (*lsp.SignatureHelp, error) {
+	m.signatureHelpParams = params
+	return m.signatureHelpResult, nil
+}
+
+func (m *mockServer) CodeAction(ctx context.Context, params *lsp.CodeActionParams) ([]lsp.CodeAction, error) {
+	m.codeActionParams = params
+	return m.codeActionResult, nil
+}
+
+// Stubs for interface satisfaction.
+func (m *mockServer) Initialize(context.Context, *lsp.InitializeParams) (*lsp.InitializeResult, error) {
+	return &lsp.InitializeResult{
+		ServerInfo: &lsp.ServerInfo{},
+	}, nil
+}
+func (m *mockServer) Initialized(context.Context, *lsp.InitializedParams) error {
+	panic("not implemented")
+}
+func (m *mockServer) Shutdown(context.Context) error { panic("not implemented") }
+func (m *mockServer) Exit(context.Context) error     { panic("not implemented") }
+func (m *mockServer) WorkDoneProgressCancel(context.Context, *lsp.WorkDoneProgressCancelParams) error {
+	return nil
+}
+func (m *mockServer) LogTrace(context.Context, *lsp.LogTraceParams) error { return nil }
+func (m *mockServer) SetTrace(context.Context, *lsp.SetTraceParams) error { return nil }
+func (m *mockServer) CodeLens(context.Context, *lsp.CodeLensParams) ([]lsp.CodeLens, error) {
+	return nil, nil
+}
+func (m *mockServer) CodeLensResolve(context.Context, *lsp.CodeLens) (*lsp.CodeLens, error) {
+	return nil, nil
+}
+func (m *mockServer) ColorPresentation(context.Context, *lsp.ColorPresentationParams) ([]lsp.ColorPresentation, error) {
+	return nil, nil
+}
+func (m *mockServer) CompletionResolve(context.Context, *lsp.CompletionItem) (*lsp.CompletionItem, error) {
+	return nil, nil
+}
+func (m *mockServer) DidChangeConfiguration(context.Context, *lsp.DidChangeConfigurationParams) error {
+	return nil
+}
+func (m *mockServer) DidChangeWatchedFiles(context.Context, *lsp.DidChangeWatchedFilesParams) error {
+	return nil
+}
+func (m *mockServer) DidChangeWorkspaceFolders(context.Context, *lsp.DidChangeWorkspaceFoldersParams) error {
+	return nil
+}
+func (m *mockServer) DidSave(context.Context, *lsp.DidSaveTextDocumentParams) error { return nil }
+func (m *mockServer) DocumentColor(context.Context, *lsp.DocumentColorParams) ([]lsp.ColorInformation, error) {
+	return nil, nil
+}
+func (m *mockServer) DocumentLinkResolve(context.Context, *lsp.DocumentLink) (*lsp.DocumentLink, error) {
+	return nil, nil
+}
+func (m *mockServer) DocumentSymbol(context.Context, *lsp.DocumentSymbolParams) ([]lsp.SymbolInformationOrDocumentSymbol, error) {
+	return nil, nil
+}
+func (m *mockServer) ExecuteCommand(context.Context, *lsp.ExecuteCommandParams) (any, error) {
+	return nil, nil
+}
+func (m *mockServer) OnTypeFormatting(context.Context, *lsp.DocumentOnTypeFormattingParams) ([]lsp.TextEdit, error) {
+	return nil, nil
+}
+func (m *mockServer) WillSaveWaitUntil(context.Context, *lsp.WillSaveTextDocumentParams) ([]lsp.TextEdit, error) {
+	return nil, nil
+}
+func (m *mockServer) ShowDocument(context.Context, *lsp.ShowDocumentParams) (*lsp.ShowDocumentResult, error) {
+	return nil, nil
+}
+func (m *mockServer) WillCreateFiles(context.Context, *lsp.CreateFilesParams) (*lsp.WorkspaceEdit, error) {
+	return nil, nil
+}
+func (m *mockServer) DidCreateFiles(context.Context, *lsp.CreateFilesParams) error { return nil }
+func (m *mockServer) WillRenameFiles(context.Context, *lsp.RenameFilesParams) (*lsp.WorkspaceEdit, error) {
+	return nil, nil
+}
+func (m *mockServer) DidRenameFiles(context.Context, *lsp.RenameFilesParams) error { return nil }
+func (m *mockServer) WillDeleteFiles(context.Context, *lsp.DeleteFilesParams) (*lsp.WorkspaceEdit, error) {
+	return nil, nil
+}
+func (m *mockServer) DidDeleteFiles(context.Context, *lsp.DeleteFilesParams) error { return nil }
+func (m *mockServer) CodeLensRefresh(context.Context) error                        { return nil }
+func (m *mockServer) SemanticTokensFullDelta(context.Context, *lsp.SemanticTokensDeltaParams) (any, error) {
+	return nil, nil
+}
+func (m *mockServer) SemanticTokensRange(context.Context, *lsp.SemanticTokensRangeParams) (*lsp.SemanticTokens, error) {
+	return nil, nil
+}
+func (m *mockServer) SemanticTokensRefresh(context.Context) error { return nil }
+func (m *mockServer) LinkedEditingRange(context.Context, *lsp.LinkedEditingRangeParams) (*lsp.LinkedEditingRanges, error) {
+	return nil, nil
+}
+func (m *mockServer) Moniker(context.Context, *lsp.MonikerParams) ([]lsp.Moniker, error) {
+	return nil, nil
+}
+func (m *mockServer) Request(context.Context, string, any) (any, error) { return nil, nil }
+
+// newTestServer creates a Server with a mock target and a pre-populated source map cache.
+// The source map maps templ line 5, cols 10..20 to Go line 15, cols 20..30.
+func newTestServer(mock *mockServer) *Server {
+	log := slog.Default()
+	cache := NewSourceMapCache()
+	cache.Set("file:///project/component.templ", newTestSourceMap())
+	return &Server{
+		Log:             log,
+		Target:          mock,
+		SourceMapCache:  cache,
+		DiagnosticCache: NewDiagnosticCache(),
+		TemplSource:     newDocumentContents(log),
+		GoSource:        make(map[string]string),
+	}
+}
+
+func goRange() lsp.Range {
+	return lsp.Range{
+		Start: lsp.Position{Line: 15, Character: 20},
+		End:   lsp.Position{Line: 15, Character: 30},
+	}
+}
+
+func templRange() lsp.Range {
+	return lsp.Range{
+		Start: lsp.Position{Line: 5, Character: 10},
+		End:   lsp.Position{Line: 5, Character: 20},
+	}
+}
+
+func TestDefinitionFromGoFile(t *testing.T) {
+	mock := &mockServer{
+		definitionResult: []lsp.Location{
+			{URI: "file:///project/component_templ.go", Range: goRange()},
+			{URI: "file:///project/other.go", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 1, Character: 5}}},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Definition(context.Background(), &lsp.DefinitionParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The request should be forwarded unchanged.
+	if mock.definitionParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI to be forwarded unchanged, got %q", mock.definitionParams.TextDocument.URI)
+	}
+	if mock.definitionParams.Position.Line != 10 {
+		t.Errorf("expected position to be forwarded unchanged, got %v", mock.definitionParams.Position)
+	}
+	// The _templ.go result should be converted to .templ.
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go URI to be converted, got %q", result[0].URI)
+	}
+	if diff := cmp.Diff(templRange(), result[0].Range); diff != "" {
+		t.Errorf("expected range to be converted (-want +got):\n%s", diff)
+	}
+	// The non-templ result should be unchanged.
+	if result[1].URI != "file:///project/other.go" {
+		t.Errorf("expected non-templ URI to be unchanged, got %q", result[1].URI)
+	}
+}
+
+func TestDefinitionFromTemplFile(t *testing.T) {
+	mock := &mockServer{
+		definitionResult: []lsp.Location{
+			{URI: "file:///project/component_templ.go", Range: goRange()},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Definition(context.Background(), &lsp.DefinitionParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The request should be rewritten to the Go file.
+	if mock.definitionParams.TextDocument.URI != "file:///project/component_templ.go" {
+		t.Errorf("expected URI to be converted to Go, got %q", mock.definitionParams.TextDocument.URI)
+	}
+	if mock.definitionParams.Position.Line != 15 || mock.definitionParams.Position.Character != 20 {
+		t.Errorf("expected position to be converted to Go, got %v", mock.definitionParams.Position)
+	}
+	// The response should be converted back.
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected URI to be converted back, got %q", result[0].URI)
+	}
+}
+
+func TestRenameFromGoFile(t *testing.T) {
+	mock := &mockServer{
+		renameResult: &lsp.WorkspaceEdit{
+			DocumentChanges: []lsp.TextDocumentEdit{
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/component_templ.go"},
+					},
+					Edits: []lsp.TextEdit{{Range: goRange(), NewText: "newName"}},
+				},
+				{
+					TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+					},
+					Edits: []lsp.TextEdit{{Range: lsp.Range{Start: lsp.Position{Line: 3, Character: 0}, End: lsp.Position{Line: 3, Character: 7}}, NewText: "newName"}},
+				},
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Rename(context.Background(), &lsp.RenameParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+		NewName: "newName",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The request should be forwarded unchanged.
+	if mock.renameParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI to be forwarded unchanged, got %q", mock.renameParams.TextDocument.URI)
+	}
+	// The _templ.go document change should be converted to .templ.
+	if result.DocumentChanges[0].TextDocument.URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go URI to be converted, got %q", result.DocumentChanges[0].TextDocument.URI)
+	}
+	if diff := cmp.Diff(templRange(), result.DocumentChanges[0].Edits[0].Range); diff != "" {
+		t.Errorf("expected range to be converted (-want +got):\n%s", diff)
+	}
+	// The .go document change should be unchanged.
+	if result.DocumentChanges[1].TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected .go URI to be unchanged, got %q", result.DocumentChanges[1].TextDocument.URI)
+	}
+}
+
+func TestRenameFromTemplFile(t *testing.T) {
+	mock := &mockServer{
+		renameResult: &lsp.WorkspaceEdit{
+			Changes: map[lsp.DocumentURI][]lsp.TextEdit{
+				"file:///project/component_templ.go": {{Range: goRange(), NewText: "newName"}},
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Rename(context.Background(), &lsp.RenameParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+		NewName: "newName",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The request should be rewritten to the Go file.
+	if mock.renameParams.TextDocument.URI != "file:///project/component_templ.go" {
+		t.Errorf("expected URI to be converted to Go, got %q", mock.renameParams.TextDocument.URI)
+	}
+	// The response should be converted.
+	if _, exists := result.Changes["file:///project/component_templ.go"]; exists {
+		t.Error("expected _templ.go key to be removed from Changes map")
+	}
+	edits, exists := result.Changes["file:///project/component.templ"]
+	if !exists {
+		t.Fatal("expected .templ key to be present in Changes map")
+	}
+	if diff := cmp.Diff(templRange(), edits[0].Range); diff != "" {
+		t.Errorf("expected range to be converted (-want +got):\n%s", diff)
+	}
+}
+
+func TestTypeDefinitionResponseConverted(t *testing.T) {
+	mock := &mockServer{
+		typeDefinitionResult: []lsp.Location{
+			{URI: "file:///project/component_templ.go", Range: goRange()},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.TypeDefinition(context.Background(), &lsp.TypeDefinitionParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected response URI to be converted, got %q", result[0].URI)
+	}
+}
+
+func TestImplementationNotHardcodedToRequestURI(t *testing.T) {
+	mock := &mockServer{
+		implementationResult: []lsp.Location{
+			{URI: "file:///project/component_templ.go", Range: goRange()},
+			{URI: "file:///project/other.go", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 1, Character: 5}}},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Implementation(context.Background(), &lsp.ImplementationParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The _templ.go result should be converted, not hardcoded to the request URI.
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go result to be converted, got %q", result[0].URI)
+	}
+	// Non-templ results should be left alone, not hardcoded.
+	if result[1].URI != "file:///project/other.go" {
+		t.Errorf("expected non-templ result to be unchanged, got %q", result[1].URI)
+	}
+}
+
+func TestDocumentHighlightNotStubbed(t *testing.T) {
+	mock := &mockServer{
+		documentHighlightResult: []lsp.DocumentHighlight{
+			{Range: goRange(), Kind: 1},
+			{Range: lsp.Range{Start: lsp.Position{Line: 15, Character: 25}, End: lsp.Position{Line: 15, Character: 30}}, Kind: 2},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.DocumentHighlight(context.Background(), &lsp.DocumentHighlightParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 highlights, got %d", len(result))
+	}
+	// Ranges should be converted back to templ positions.
+	if result[0].Range.Start.Line != 5 {
+		t.Errorf("expected highlight range to be converted, got line %d", result[0].Range.Start.Line)
+	}
+}
+
+func TestDocumentHighlightDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.DocumentHighlight(context.Background(), &lsp.DocumentHighlightParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 3, Character: 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.documentHighlightParams != nil {
+		t.Error("expected DocumentHighlight to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestDidChangeForwardsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	err := s.DidChange(context.Background(), &lsp.DidChangeTextDocumentParams{
+		TextDocument: lsp.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+		},
+		ContentChanges: []lsp.TextDocumentContentChangeEvent{{Text: "package main"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.didChangeParams == nil {
+		t.Fatal("expected DidChange to be forwarded to gopls for .go files")
+	}
+	if mock.didChangeParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI to be forwarded unchanged, got %q", mock.didChangeParams.TextDocument.URI)
+	}
+}
+
+func TestDidOpenForwardsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	err := s.HandleDidOpen(context.Background(), &lsp.DidOpenTextDocumentParams{
+		TextDocument: lsp.TextDocumentItem{URI: "file:///project/main.go", Text: "package main"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.didOpenParams == nil {
+		t.Fatal("expected DidOpen to be forwarded to gopls for .go files")
+	}
+	if mock.didOpenParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI to be forwarded unchanged, got %q", mock.didOpenParams.TextDocument.URI)
+	}
+}
+
+func TestDidCloseForwardsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	err := s.HandleDidClose(context.Background(), &lsp.DidCloseTextDocumentParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.didCloseParams == nil {
+		t.Fatal("expected DidClose to be forwarded to gopls for .go files")
+	}
+}
+
+func TestWillSaveForwardsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	err := s.WillSave(context.Background(), &lsp.WillSaveTextDocumentParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.willSaveParams == nil {
+		t.Fatal("expected WillSave to be forwarded to gopls for .go files")
+	}
+	if mock.willSaveParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI to be forwarded unchanged, got %q", mock.willSaveParams.TextDocument.URI)
+	}
+}
+
+func TestFoldingRangesDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.FoldingRanges(context.Background(), &lsp.FoldingRangeParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.foldingRangesParams != nil {
+		t.Error("expected FoldingRanges to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestFoldingRangesReturnsEmptyForTemplFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.FoldingRanges(context.Background(), &lsp.FoldingRangeParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.foldingRangesParams != nil {
+		t.Error("expected FoldingRanges to not be forwarded for templ files")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result for templ files, got %v", result)
+	}
+}
+
+func TestSemanticTokensDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.SemanticTokensFull(context.Background(), &lsp.SemanticTokensParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.semanticTokensFullParams != nil {
+		t.Error("expected SemanticTokensFull to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestDocumentLinkDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.DocumentLink(context.Background(), &lsp.DocumentLinkParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.documentLinkParams != nil {
+		t.Error("expected DocumentLink to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestCompletionDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.Completion(context.Background(), &lsp.CompletionParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.completionParams != nil {
+		t.Error("expected Completion to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestFormattingDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.Formatting(context.Background(), &lsp.DocumentFormattingParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.formattingParams != nil {
+		t.Error("expected Formatting to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestRangeFormattingConvertsRange(t *testing.T) {
+	mock := &mockServer{
+		rangeFormattingResult: []lsp.TextEdit{{Range: goRange(), NewText: "formatted"}},
+	}
+	s := newTestServer(mock)
+	result, err := s.RangeFormatting(context.Background(), &lsp.DocumentRangeFormattingParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+		Range:        templRange(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The request range should have been converted.
+	if mock.rangeFormattingParams.Range.Start.Line != 15 {
+		t.Errorf("expected request range to be converted to Go, got %v", mock.rangeFormattingParams.Range)
+	}
+	// The response range should be converted back.
+	if diff := cmp.Diff(templRange(), result[0].Range); diff != "" {
+		t.Errorf("expected response range to be converted back (-want +got):\n%s", diff)
+	}
+}
+
+func TestRangeFormattingDropsGoFiles(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.RangeFormatting(context.Background(), &lsp.DocumentRangeFormattingParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+		Range:        lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 5, Character: 0}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.rangeFormattingParams != nil {
+		t.Error("expected RangeFormatting to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+func TestReferencesFromGoFile(t *testing.T) {
+	mock := &mockServer{
+		referencesResult: []lsp.Location{
+			{URI: "file:///project/component_templ.go", Range: goRange()},
+			{URI: "file:///project/main.go", Range: lsp.Range{Start: lsp.Position{Line: 3, Character: 0}, End: lsp.Position{Line: 3, Character: 5}}},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.References(context.Background(), &lsp.ReferenceParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Request forwarded unchanged.
+	if mock.referencesParams.TextDocument.URI != "file:///project/main.go" {
+		t.Errorf("expected URI forwarded unchanged, got %q", mock.referencesParams.TextDocument.URI)
+	}
+	// _templ.go reference converted to .templ.
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go reference to be converted, got %q", result[0].URI)
+	}
+	// .go reference unchanged.
+	if result[1].URI != "file:///project/main.go" {
+		t.Errorf("expected .go reference to be unchanged, got %q", result[1].URI)
+	}
+}
+
+func TestPrepareCallHierarchyConvertsItems(t *testing.T) {
+	mock := &mockServer{
+		prepareCallHierarchyResult: []lsp.CallHierarchyItem{
+			{
+				Name:           "MyComponent",
+				URI:            "file:///project/component_templ.go",
+				Range:          goRange(),
+				SelectionRange: goRange(),
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.PrepareCallHierarchy(context.Background(), &lsp.CallHierarchyPrepareParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+			Position:     lsp.Position{Line: 5, Character: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].URI != "file:///project/component.templ" {
+		t.Errorf("expected URI to be converted, got %q", result[0].URI)
+	}
+	if diff := cmp.Diff(templRange(), result[0].Range); diff != "" {
+		t.Errorf("expected Range to be converted (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(templRange(), result[0].SelectionRange); diff != "" {
+		t.Errorf("expected SelectionRange to be converted (-want +got):\n%s", diff)
+	}
+}
+
+func TestIncomingCallsConvertsFromItems(t *testing.T) {
+	mock := &mockServer{
+		incomingCallsResult: []lsp.CallHierarchyIncomingCall{
+			{
+				From: lsp.CallHierarchyItem{
+					Name:           "Caller",
+					URI:            "file:///project/component_templ.go",
+					Range:          goRange(),
+					SelectionRange: goRange(),
+				},
+				FromRanges: []lsp.Range{goRange()},
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.IncomingCalls(context.Background(), &lsp.CallHierarchyIncomingCallsParams{
+		Item: lsp.CallHierarchyItem{Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].From.URI != "file:///project/component.templ" {
+		t.Errorf("expected From URI to be converted, got %q", result[0].From.URI)
+	}
+	if diff := cmp.Diff(templRange(), result[0].FromRanges[0]); diff != "" {
+		t.Errorf("expected FromRanges to be converted (-want +got):\n%s", diff)
+	}
+}
+
+func TestOutgoingCallsConvertsToItems(t *testing.T) {
+	mock := &mockServer{
+		outgoingCallsResult: []lsp.CallHierarchyOutgoingCall{
+			{
+				To: lsp.CallHierarchyItem{
+					Name:           "Callee",
+					URI:            "file:///project/component_templ.go",
+					Range:          goRange(),
+					SelectionRange: goRange(),
+				},
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.OutgoingCalls(context.Background(), &lsp.CallHierarchyOutgoingCallsParams{
+		Item: lsp.CallHierarchyItem{Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].To.URI != "file:///project/component.templ" {
+		t.Errorf("expected To URI to be converted, got %q", result[0].To.URI)
+	}
+}
+
+func TestSymbolsConvertsTemplGoLocations(t *testing.T) {
+	mock := &mockServer{
+		symbolsResult: []lsp.SymbolInformation{
+			{
+				Name:     "MyComponent",
+				Location: lsp.Location{URI: "file:///project/component_templ.go", Range: goRange()},
+			},
+			{
+				Name:     "main",
+				Location: lsp.Location{URI: "file:///project/main.go", Range: lsp.Range{Start: lsp.Position{Line: 1, Character: 0}, End: lsp.Position{Line: 1, Character: 4}}},
+			},
+		},
+	}
+	s := newTestServer(mock)
+	result, err := s.Symbols(context.Background(), &lsp.WorkspaceSymbolParams{Query: "My"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[0].Location.URI != "file:///project/component.templ" {
+		t.Errorf("expected _templ.go symbol location to be converted, got %q", result[0].Location.URI)
+	}
+	if result[1].Location.URI != "file:///project/main.go" {
+		t.Errorf("expected .go symbol location to be unchanged, got %q", result[1].Location.URI)
+	}
+}
+
+func TestSignatureHelpDropsGoFiles(t *testing.T) {
+	mock := &mockServer{
+		signatureHelpResult: &lsp.SignatureHelp{},
+	}
+	s := newTestServer(mock)
+	result, err := s.SignatureHelp(context.Background(), &lsp.SignatureHelpParams{
+		TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+			TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/main.go"},
+			Position:     lsp.Position{Line: 10, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.signatureHelpParams != nil {
+		t.Error("expected SignatureHelp to not be forwarded for .go files")
+	}
+	if result != nil {
+		t.Errorf("expected nil result for .go files, got %v", result)
+	}
+}
+
+// newTestSourceMapMulti creates a source map with two expressions for testing CodeAction.
+func newTestSourceMapMulti() *parser.SourceMap {
+	sm := parser.NewSourceMap()
+	// Map a whole line range: templ line 3, col 0..10 -> Go line 10, col 0..10.
+	sm.Add(
+		parser.Expression{
+			Value: "0123456789",
+			Range: parser.Range{
+				From: parser.Position{Index: 0, Line: 3, Col: 0},
+				To:   parser.Position{Index: 10, Line: 3, Col: 10},
+			},
+		},
+		parser.Range{
+			From: parser.Position{Index: 0, Line: 10, Col: 0},
+			To:   parser.Position{Index: 10, Line: 10, Col: 10},
+		},
+	)
+	return sm
+}
+
+func TestCodeActionConvertsWorkspaceEdit(t *testing.T) {
+	mock := &mockServer{
+		codeActionResult: []lsp.CodeAction{
+			{
+				Title: "Organize Imports",
+				Edit: &lsp.WorkspaceEdit{
+					DocumentChanges: []lsp.TextDocumentEdit{
+						{
+							TextDocument: lsp.OptionalVersionedTextDocumentIdentifier{
+								TextDocumentIdentifier: lsp.TextDocumentIdentifier{URI: "file:///project/component_templ.go"},
+							},
+							Edits: []lsp.TextEdit{{Range: lsp.Range{Start: lsp.Position{Line: 10, Character: 0}, End: lsp.Position{Line: 10, Character: 10}}, NewText: "import"}},
+						},
+					},
+				},
+			},
+			{
+				Title: "Unsupported Action",
+			},
+		},
+	}
+	cache := NewSourceMapCache()
+	cache.Set("file:///project/component.templ", newTestSourceMapMulti())
+	log := slog.Default()
+	s := &Server{
+		Log:             log,
+		Target:          mock,
+		SourceMapCache:  cache,
+		DiagnosticCache: NewDiagnosticCache(),
+		TemplSource:     newDocumentContents(log),
+		GoSource:        make(map[string]string),
+	}
+	result, err := s.CodeAction(context.Background(), &lsp.CodeActionParams{
+		TextDocument: lsp.TextDocumentIdentifier{URI: "file:///project/component.templ"},
+		Range: lsp.Range{
+			Start: lsp.Position{Line: 3, Character: 0},
+			End:   lsp.Position{Line: 3, Character: 5},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only "Organize Imports" should pass through.
+	if len(result) != 1 {
+		t.Fatalf("expected 1 code action (unsupported filtered), got %d", len(result))
+	}
+	if result[0].Title != "Organize Imports" {
+		t.Errorf("expected Organize Imports, got %q", result[0].Title)
+	}
+	// Workspace edit should be converted.
+	if result[0].Edit.DocumentChanges[0].TextDocument.URI != "file:///project/component.templ" {
+		t.Errorf("expected document change URI to be converted, got %q", result[0].Edit.DocumentChanges[0].TextDocument.URI)
+	}
+}
+
+func TestInitializeAdvertisesGoFileSupport(t *testing.T) {
+	mock := &mockServer{}
+	s := newTestServer(mock)
+	result, err := s.Initialize(context.Background(), &lsp.InitializeParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	experimental, ok := result.Capabilities.Experimental.(map[string]any)
+	if !ok {
+		t.Fatal("expected Experimental to be map[string]any")
+	}
+	templ, ok := experimental["templ"].(map[string]any)
+	if !ok {
+		t.Fatal("expected experimental.templ to be map[string]any")
+	}
+	goFileSupport, ok := templ["goFileSupport"].(bool)
+	if !ok || !goFileSupport {
+		t.Errorf("expected experimental.templ.goFileSupport to be true, got %v", templ["goFileSupport"])
+	}
+}


### PR DESCRIPTION
See https://github.com/a-h/templ/issues/387

# LSP proxy: .go file support and bug fixes

## Summary

The proxy now handles requests from `.go` files (not just `.templ`), enabling cross-file navigation (e.g. "Go to Definition" on a templ component from a `.go` file). Several broken LSP methods are fixed.

## How it works

### Routing: `proxyPositionRequest`

Replaces the old `updatePosition` method. For `.templ` files, it converts the cursor position via source maps to the generated `_templ.go` position. For `.go` files, it passes the position through unchanged. Returns `ok=false` only when a `.templ` source map lookup fails, causing the handler to return nil.

Navigation methods (Definition, Declaration, References, TypeDefinition, Implementation, Rename, PrepareRename, PrepareCallHierarchy) all use this helper. After gopls responds, `_templ.go` URIs and ranges in results are converted back to `.templ` using `convertLocationResults` or `convertCallHierarchyItem`.

### Duplicative features return nil for .go files

Hover, Completion, Formatting, RangeFormatting, CodeAction, DocumentHighlight, DocumentLink, SignatureHelp, OnTypeFormatting, FoldingRanges, SemanticTokens, and Moniker return nil when the request URI is a non-templ `.go` file. The Go extension already provides these for `.go` files.

### Document sync forwards .go files

DidChange, DidOpen, and DidClose forward `.go` file notifications to gopls so it maintains accurate workspace state.

### Shared conversion helpers (`rewrite.go`)

- `convertGoRangeToTemplRange` -- uses the source map cache to map a Go range back to templ source.
- `convertLocationResults` -- converts `_templ.go` URIs/ranges in `[]lsp.Location` results.
- `convertCallHierarchyItem` -- converts a call hierarchy item's URI, Range, and SelectionRange.
- `convertWorkspaceEdit` -- converts `_templ.go` URIs/ranges in both `DocumentChanges` and `Changes` maps.
- `isNonTemplGoURI` -- returns true for `.go` files that are not `_templ.go`.

### Client-side fixes (`client.go`)

- `ApplyEdit` now calls `convertWorkspaceEdit` before forwarding to the editor.
- `PublishDiagnostics` silently drops diagnostics for regular `.go` files (the Go extension publishes those) instead of returning an error.

## Bug fixes

| Method | Fix |
|--------|-----|
| Rename | Now converts request position and response workspace edit (was pass-through) |
| TypeDefinition | Now converts response locations (was missing) |
| Implementation | Uses `convertLocationResults` instead of hardcoding request URI |
| DocumentHighlight | Implemented (was stubbed to return empty) |
| RangeFormatting | Converts range parameter before forwarding (was missing) |
| CodeAction | Enabled "Organize Imports"; uses `convertWorkspaceEdit` for edits (was empty allowlist) |
| PrepareCallHierarchy | Converts response items (was pass-through) |
| IncomingCalls/OutgoingCalls | Converts response items (was pass-through) |
| Symbols | Converts `_templ.go` locations in response (was pass-through) |

## Capability negotiation

The proxy advertises `experimental.templ.goFileSupport: true` in its Initialize response. Editors can check this before routing `.go` files to the proxy, ensuring safe independent upgrades of extension and templ binary.

## Testing

New unit tests in `server_test.go`, `client_test.go`, and `rewrite_test.go` verify each behavior using mock servers/clients. The integration test for CodeAction now asserts "Organize Imports" is returned.
