### PR TITLE
fix: failure to parse large templ files

### DIFF
--- a/parser/v2/goparser.go
+++ b/parser/v2/goparser.go
@@ -15,7 +15,7 @@ func parseGoFuncDecl(prefix string, pi *parse.Input) (name string, expression Ex
 	from := pi.Index()
 	src, _ := pi.Peek(-1)
 	src = strings.TrimPrefix(src, prefix)
-	decl, err := funcDeclSource(src)
+	decl, err := extractFuncDeclSignature(src)
 	if err != nil {
 		return name, expression, parse.Error(fmt.Sprintf("invalid %s declaration: %v", prefix, err.Error()), pi.Position())
 	}
@@ -28,7 +28,7 @@ func parseGoFuncDecl(prefix string, pi *parse.Input) (name string, expression Ex
 	return name, NewExpression(expr, pi.PositionAt(from+len(prefix)), to), nil
 }
 
-func funcDeclSource(src string) (string, error) {
+func extractFuncDeclSignature(src string) (string, error) {
 	var s scanner.Scanner
 	fset := token.NewFileSet()
 	file := fset.AddFile("", fset.Base(), len(src))

--- a/parser/v2/goparser.go
+++ b/parser/v2/goparser.go
@@ -36,10 +36,12 @@ func funcDeclSource(src string) (string, error) {
 
 	var parenDepth, bracketDepth, braceDepth int
 	for {
-		pos, tok, _ := s.Scan()
+		pos, tok, lit := s.Scan()
 		switch tok {
 		case token.EOF:
 			return "", fmt.Errorf("function body open brace not found")
+		case token.ILLEGAL:
+			return "", fmt.Errorf("illegal token %q in declaration", lit)
 		case token.LPAREN:
 			parenDepth++
 		case token.RPAREN:

--- a/parser/v2/goparser.go
+++ b/parser/v2/goparser.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"fmt"
+	"go/scanner"
+	"go/token"
 	"strings"
 
 	"github.com/a-h/parse"
@@ -13,13 +15,54 @@ func parseGoFuncDecl(prefix string, pi *parse.Input) (name string, expression Ex
 	from := pi.Index()
 	src, _ := pi.Peek(-1)
 	src = strings.TrimPrefix(src, prefix)
-	name, expr, err := goexpression.Func("func " + src)
+	decl, err := funcDeclSource(src)
+	if err != nil {
+		return name, expression, parse.Error(fmt.Sprintf("invalid %s declaration: %v", prefix, err.Error()), pi.Position())
+	}
+	name, expr, err := goexpression.Func("func " + decl + "{}")
 	if err != nil {
 		return name, expression, parse.Error(fmt.Sprintf("invalid %s declaration: %v", prefix, err.Error()), pi.Position())
 	}
 	pi.Take(len(prefix) + len(expr))
 	to := pi.Position()
 	return name, NewExpression(expr, pi.PositionAt(from+len(prefix)), to), nil
+}
+
+func funcDeclSource(src string) (string, error) {
+	var s scanner.Scanner
+	fset := token.NewFileSet()
+	file := fset.AddFile("", fset.Base(), len(src))
+	s.Init(file, []byte(src), nil, scanner.ScanComments)
+
+	var parenDepth, bracketDepth, braceDepth int
+	for {
+		pos, tok, _ := s.Scan()
+		switch tok {
+		case token.EOF:
+			return "", fmt.Errorf("function body open brace not found")
+		case token.LPAREN:
+			parenDepth++
+		case token.RPAREN:
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case token.LBRACK:
+			bracketDepth++
+		case token.RBRACK:
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case token.LBRACE:
+			if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 {
+				return src[:int(pos)-1], nil
+			}
+			braceDepth++
+		case token.RBRACE:
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		}
+	}
 }
 
 func parseTemplFuncDecl(pi *parse.Input) (name string, expression Expression, err error) {

--- a/parser/v2/goparser_test.go
+++ b/parser/v2/goparser_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestFuncDeclSource(t *testing.T) {
+func TestExtractFuncDeclSignature(t *testing.T) {
 	tests := []struct {
 		name     string
 		src      string
@@ -75,7 +75,7 @@ func TestFuncDeclSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := funcDeclSource(tt.src)
+			got, err := extractFuncDeclSignature(tt.src)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -86,7 +86,7 @@ func TestFuncDeclSource(t *testing.T) {
 	}
 }
 
-func TestFuncDeclSourceReturnsErrorWhenBodyBraceIsMissing(t *testing.T) {
+func TestExtractFuncDeclSignatureReturnsErrorWhenBodyBraceIsMissing(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
@@ -98,7 +98,7 @@ func TestFuncDeclSourceReturnsErrorWhenBodyBraceIsMissing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := funcDeclSource(tt.src)
+			_, err := extractFuncDeclSignature(tt.src)
 			if err == nil {
 				t.Fatal("expected an error, got nil")
 			}
@@ -157,7 +157,7 @@ func TestParseStringExtractsComplexTemplSignatures(t *testing.T) {
 	}
 }
 
-func FuzzFuncDeclSource(f *testing.F) {
+func FuzzExtractFuncDeclSignature(f *testing.F) {
 	seeds := []string{
 		"Component() {\n}",
 		"Component[T any](v struct{ X int }) {\n}",
@@ -170,7 +170,7 @@ func FuzzFuncDeclSource(f *testing.F) {
 		f.Add(seed)
 	}
 	f.Fuzz(func(t *testing.T, src string) {
-		decl, err := funcDeclSource(src)
+		decl, err := extractFuncDeclSignature(src)
 		if err != nil {
 			return
 		}
@@ -183,11 +183,11 @@ func FuzzFuncDeclSource(f *testing.F) {
 	})
 }
 
-func BenchmarkFuncDeclSource(b *testing.B) {
+func BenchmarkExtractFuncDeclSignature(b *testing.B) {
 	src := "Component[T any](name string, items []T, v struct{ X int }) {\n\t<p>Body</p>\n}"
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := funcDeclSource(src); err != nil {
+		if _, err := extractFuncDeclSignature(src); err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
 	}

--- a/parser/v2/goparser_test.go
+++ b/parser/v2/goparser_test.go
@@ -1,0 +1,221 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFuncDeclSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected string
+	}{
+		{
+			name:     "a simple declaration is extracted up to the body brace",
+			src:      "Component() {\n\t<p>Hello</p>\n}",
+			expected: "Component() ",
+		},
+		{
+			name:     "parameters are included in the extracted declaration",
+			src:      "Component(name string, count int) {\n}",
+			expected: "Component(name string, count int) ",
+		},
+		{
+			name:     "a variadic parameter is included",
+			src:      "Component(items ...string) {\n}",
+			expected: "Component(items ...string) ",
+		},
+		{
+			name:     "a single type parameter is included",
+			src:      "Component[T any]() {\n}",
+			expected: "Component[T any]() ",
+		},
+		{
+			name:     "multiple type parameters are included",
+			src:      "Component[T, U any](t T, u U) {\n}",
+			expected: "Component[T, U any](t T, u U) ",
+		},
+		{
+			name:     "a struct-typed parameter does not terminate scanning at its opening brace",
+			src:      "Component(v struct{ X int }) {\n}",
+			expected: "Component(v struct{ X int }) ",
+		},
+		{
+			name:     "an empty struct-typed parameter does not terminate scanning",
+			src:      "Component(v struct{}) {\n}",
+			expected: "Component(v struct{}) ",
+		},
+		{
+			name:     "a func-typed parameter is included",
+			src:      "Component(fn func(a int) error) {\n}",
+			expected: "Component(fn func(a int) error) ",
+		},
+		{
+			name:     "a map-typed parameter with braces does not terminate scanning",
+			src:      "Component(m map[string]struct{ Y int }) {\n}",
+			expected: "Component(m map[string]struct{ Y int }) ",
+		},
+		{
+			name:     "a generic struct-typed parameter combining brackets and braces is handled",
+			src:      "Component[T any](v struct{ Items []T }) {\n}",
+			expected: "Component[T any](v struct{ Items []T }) ",
+		},
+		{
+			name:     "a comment before the body brace does not terminate scanning",
+			src:      "Component() /* body */ {\n}",
+			expected: "Component() /* body */ ",
+		},
+		{
+			name:     "a brace inside a string literal parameter default does not terminate scanning",
+			src:      "Component(s string) {\n\t<p>{ \"}\" }</p>\n}",
+			expected: "Component(s string) ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := funcDeclSource(tt.src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("got %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFuncDeclSourceReturnsErrorWhenBodyBraceIsMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "an empty source has no body brace", src: ""},
+		{name: "a signature without a body has no body brace", src: "Component()"},
+		{name: "an unclosed parameter list has no body brace", src: "Component(name string"},
+		{name: "an illegal token fails before the body brace is reached", src: "Component(name #string) {\n}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := funcDeclSource(tt.src)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseStringExtractsComplexTemplSignatures(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		expectedExpr string
+	}{
+		{
+			name:         "a generic component signature is extracted",
+			src:          "package main\n\ntempl Component[T any](items []T) {\n\t<p>Hello</p>\n}\n",
+			expectedExpr: "Component[T any](items []T)",
+		},
+		{
+			name:         "a struct-typed parameter is extracted",
+			src:          "package main\n\ntempl Component(v struct{ X int }) {\n\t<p>Hello</p>\n}\n",
+			expectedExpr: "Component(v struct{ X int })",
+		},
+		{
+			name:         "a func-typed parameter is extracted",
+			src:          "package main\n\ntempl Component(fn func(a int) error) {\n\t<p>Hello</p>\n}\n",
+			expectedExpr: "Component(fn func(a int) error)",
+		},
+		{
+			name:         "multiple type parameters are extracted",
+			src:          "package main\n\ntempl Component[T, U any](t T, u U) {\n\t<p>Hello</p>\n}\n",
+			expectedExpr: "Component[T, U any](t T, u U)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf, err := ParseString(tt.src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var found bool
+			for _, n := range tf.Nodes {
+				tmpl, ok := n.(*HTMLTemplate)
+				if !ok {
+					continue
+				}
+				found = true
+				if tmpl.Expression.Value != tt.expectedExpr {
+					t.Errorf("got expression %q, expected %q", tmpl.Expression.Value, tt.expectedExpr)
+				}
+			}
+			if !found {
+				t.Fatal("expected an HTMLTemplate node, found none")
+			}
+		})
+	}
+}
+
+func FuzzFuncDeclSource(f *testing.F) {
+	seeds := []string{
+		"Component() {\n}",
+		"Component[T any](v struct{ X int }) {\n}",
+		"Component(fn func(a int) error) {\n}",
+		"Component(",
+		"",
+		"{}",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		decl, err := funcDeclSource(src)
+		if err != nil {
+			return
+		}
+		if !strings.HasPrefix(src, decl) {
+			t.Fatalf("returned declaration %q is not a prefix of source %q", decl, src)
+		}
+		if len(decl) >= len(src) || src[len(decl)] != '{' {
+			t.Fatalf("returned declaration %q must be immediately followed by an opening brace in source %q", decl, src)
+		}
+	})
+}
+
+func BenchmarkFuncDeclSource(b *testing.B) {
+	src := "Component[T any](name string, items []T, v struct{ X int }) {\n\t<p>Body</p>\n}"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := funcDeclSource(src); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func generateTemplFile(components, rowsPerComponent int) string {
+	var sb strings.Builder
+	sb.WriteString("package main\n\n")
+	for i := range components {
+		fmt.Fprintf(&sb, "templ Component%d(name string, count int) {\n", i)
+		for j := range rowsPerComponent {
+			fmt.Fprintf(&sb, "\t<p>Some HTML content for component %d row %d.</p>\n", i, j)
+		}
+		sb.WriteString("}\n\n")
+	}
+	return sb.String()
+}
+
+func BenchmarkParseStringManyComponents(b *testing.B) {
+	for _, components := range []int{10, 40, 80} {
+		src := generateTemplFile(components, 40)
+		b.Run(fmt.Sprintf("components=%d", components), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := ParseString(src); err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/parser/v2/templatefile_test.go
+++ b/parser/v2/templatefile_test.go
@@ -1,7 +1,9 @@
 package parser
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -239,5 +241,22 @@ func TestDefaultPackageName(t *testing.T) {
 				t.Errorf("expected %q got %q", tt.expected, actual)
 			}
 		})
+	}
+}
+
+func TestTemplateFileParserLargeFileWithManyTemplates(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("package main\n\n")
+	for i := 0; i < 80; i++ {
+		_, _ = fmt.Fprintf(&sb, "templ Component%d() {\n", i)
+		for j := 0; j < 40; j++ {
+			_, _ = fmt.Fprintf(&sb, "\t<p>Some HTML content for component %d row %d.</p>\n", i, j)
+		}
+		sb.WriteString("}\n\n")
+	}
+
+	_, err := ParseString(sb.String())
+	if err != nil {
+		t.Fatalf("expected large template file to parse: %v", err)
 	}
 }


### PR DESCRIPTION
Fix templ parser failure on large `.templ` files

This fixes a parser failure where large `.templ` files could report a misleading error near the top of the file, for example:

`templ: malformed templ expression, expected templ functionName() {: line 3, col 0`

## Root cause

`parseGoFuncDecl` passed the entire remaining `.templ` source into the Go expression parser when extracting a templ function declaration. For large files, that meant the parser also saw all following templ/HTML content after the current declaration, and Go parser recovery could fail before templ got to the real content.

## Fix

Scan only the templ function declaration prefix, up to the opening brace of the function body, then parse that as a normal Go function declaration.

This keeps the Go parser focused on:

`func Name(...) {}`

instead of the entire rest of the `.templ` file.

## Tests

Added a regression test with many generated templ components to cover large files with substantial trailing content.

Verified with:

`go test ./parser/v2/...`