### PR TITLE
feat: track element tag ranges

### DIFF
--- a/parser/v2/elementparser.go
+++ b/parser/v2/elementparser.go
@@ -12,11 +12,12 @@ import (
 
 // Element open tag.
 type elementOpenTag struct {
-	Name        string
-	Attributes  []Attribute
-	IndentAttrs bool
-	NameRange   Range
-	Void        bool
+	Name         string
+	Attributes   []Attribute
+	IndentAttrs  bool
+	NameRange    Range
+	OpenTagRange Range
+	SelfClosing  bool
 }
 
 var elementOpenTagParser = parse.Func(func(pi *parse.Input) (e elementOpenTag, matched bool, err error) {
@@ -25,10 +26,12 @@ var elementOpenTagParser = parse.Func(func(pi *parse.Input) (e elementOpenTag, m
 		return e, false, nil
 	}
 
+	startIndex := pi.Index()
 	// <
 	if _, matched, err = lt.Parse(pi); err != nil || !matched {
 		return
 	}
+	openTagStart := pi.PositionAt(startIndex)
 
 	// Element name.
 	l := pi.Position().Line
@@ -65,7 +68,8 @@ var elementOpenTagParser = parse.Func(func(pi *parse.Input) (e elementOpenTag, m
 		return e, true, err
 	}
 	if matched {
-		e.Void = true
+		e.OpenTagRange = NewRange(openTagStart, pi.Position())
+		e.SelfClosing = true
 		return e, true, nil
 	}
 
@@ -79,6 +83,8 @@ var elementOpenTagParser = parse.Func(func(pi *parse.Input) (e elementOpenTag, m
 		err = parse.Error(fmt.Sprintf("<%s>: malformed open element", e.Name), pi.Position())
 		return
 	}
+
+	e.OpenTagRange = NewRange(openTagStart, pi.Position())
 
 	return e, true, nil
 })
@@ -560,17 +566,19 @@ func (elementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 		return
 	}
 	r := &Element{
-		Name:        ot.Name,
-		Attributes:  ot.Attributes,
-		IndentAttrs: ot.IndentAttrs,
-		NameRange:   ot.NameRange,
+		Name:         ot.Name,
+		Attributes:   ot.Attributes,
+		IndentAttrs:  ot.IndentAttrs,
+		NameRange:    ot.NameRange,
+		OpenTagRange: ot.OpenTagRange,
+		SelfClosing:  ot.SelfClosing,
 	}
 
 	// Once we've got an open tag, the rest must be present.
 	l := pi.Position().Line
 
 	// If the element is self-closing, even if it's not really a void element (br, hr etc.), we can return early.
-	if ot.Void || r.IsVoidElement() {
+	if ot.SelfClosing || r.IsVoidElement() {
 		// Escape early, no need to try to parse children for self-closing elements.
 		return addTrailingSpaceAndValidate(start, r, pi)
 	}
@@ -595,6 +603,7 @@ func (elementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 	}
 
 	// Close tag.
+	closeTagStart := pi.Position()
 	_, ok, err = closer.Parse(pi)
 	if err != nil {
 		return r, true, err
@@ -603,6 +612,8 @@ func (elementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 		err = parse.Error(fmt.Sprintf("<%s>: expected end tag not present or invalid tag contents", r.Name), pi.Position())
 		return r, true, err
 	}
+	closeTagRange := NewRange(closeTagStart, pi.Position())
+	r.CloseTagRange = &closeTagRange
 
 	return addTrailingSpaceAndValidate(start, r, pi)
 }

--- a/parser/v2/elementparser_test.go
+++ b/parser/v2/elementparser_test.go
@@ -27,6 +27,10 @@ func TestAttributeParser(t *testing.T) {
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 2, Line: 0, Col: 2},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 3, Line: 0, Col: 3},
+				},
 			},
 		},
 		{
@@ -38,6 +42,10 @@ func TestAttributeParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 12, Line: 0, Col: 12},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 13, Line: 0, Col: 13},
 				},
 			},
 		},
@@ -70,6 +78,10 @@ func TestAttributeParser(t *testing.T) {
 							To:   Position{Index: 20, Line: 0, Col: 20},
 						},
 					},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
 			},
 		},
@@ -121,6 +133,10 @@ func TestAttributeParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 49, Line: 0, Col: 49},
+				},
 			},
 		},
 		{
@@ -170,6 +186,10 @@ func TestAttributeParser(t *testing.T) {
 							To:   Position{Index: 35, Line: 0, Col: 35},
 						},
 					},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 36, Line: 0, Col: 36},
 				},
 			},
 		},
@@ -647,6 +667,10 @@ if test {` + " " + `
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 10, Line: 0, Col: 10},
+				},
 			},
 		},
 		{
@@ -684,6 +708,10 @@ if test {` + " " + `
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
 			},
 		},
 		{
@@ -712,10 +740,15 @@ if test {` + " " + `
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 2, Col: 3},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 21, Line: 2, Col: 3},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -744,10 +777,12 @@ if test {` + " " + `
 						},
 					},
 				},
+				OpenTagRange: Range{To: Position{Index: 23, Line: 2, Col: 3}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 23, Line: 2, Col: 3},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -911,10 +946,12 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{From: Position{Index: 0, Line: 0, Col: 0}, To: Position{Index: 16, Line: 0, Col: 16}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 16, Line: 0, Col: 16},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -925,6 +962,14 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 10, Line: 0, Col: 10},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
@@ -950,6 +995,14 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 10, Line: 0, Col: 10},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 17, Line: 0, Col: 17},
+					To:   Position{Index: 28, Line: 0, Col: 28},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 28, Line: 0, Col: 28},
@@ -965,7 +1018,8 @@ func TestElementParser(t *testing.T) {
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 6, Line: 0, Col: 6},
 				},
-				Children: nil,
+				Children:     nil,
+				OpenTagRange: Range{From: Position{Index: 0, Line: 0, Col: 0}, To: Position{Index: 7, Line: 0, Col: 7}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 7, Line: 0, Col: 7},
@@ -981,7 +1035,8 @@ func TestElementParser(t *testing.T) {
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 3, Line: 0, Col: 3},
 				},
-				Children: nil,
+				Children:     nil,
+				OpenTagRange: Range{From: Position{Index: 0, Line: 0, Col: 0}, To: Position{Index: 4, Line: 0, Col: 4}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 4, Line: 0, Col: 4},
@@ -1012,7 +1067,8 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
-				Children: nil,
+				Children:     nil,
+				OpenTagRange: Range{From: Position{Index: 0, Line: 0, Col: 0}, To: Position{Index: 12, Line: 0, Col: 12}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 12, Line: 0, Col: 12},
@@ -1031,6 +1087,10 @@ func TestElementParser(t *testing.T) {
 				// <input> is a void element, so text is not a child of the input.
 				// </input> is ignored.
 				Children: nil,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 7, Line: 0, Col: 7},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 7, Line: 0, Col: 7},
@@ -1076,10 +1136,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 23, Line: 0, Col: 23},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 23, Line: 0, Col: 23},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1098,6 +1163,7 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 6, Line: 0, Col: 6},
 							To:   Position{Index: 8, Line: 0, Col: 8},
 						},
+						OpenTagRange: Range{From: Position{Index: 5, Col: 5}, To: Position{Index: 9, Col: 9}},
 						Range: Range{
 							From: Position{Index: 5, Line: 0, Col: 5},
 							To:   Position{Index: 9, Line: 0, Col: 9},
@@ -1109,12 +1175,15 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 10, Line: 0, Col: 10},
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
+						OpenTagRange: Range{From: Position{Index: 9, Col: 9}, To: Position{Index: 13, Col: 13}},
 						Range: Range{
 							From: Position{Index: 9, Line: 0, Col: 9},
 							To:   Position{Index: 18, Line: 0, Col: 18},
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 5, Col: 5}},
+				CloseTagRange: &Range{From: Position{Index: 18, Col: 18}, To: Position{Index: 24, Col: 24}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 24, Line: 0, Col: 24},
@@ -1133,6 +1202,10 @@ func TestElementParser(t *testing.T) {
 				// <br> is a void element, so <hr> is not a child of the <br>.
 				// </br> is ignored.
 				Children: nil,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 4, Line: 0, Col: 4},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 4, Line: 0, Col: 4},
@@ -1182,10 +1255,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 20, Line: 0, Col: 20},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 20, Line: 0, Col: 20},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1235,10 +1313,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 45, Line: 0, Col: 45},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 45, Line: 0, Col: 45},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1294,10 +1377,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 39, Line: 0, Col: 39},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 39, Line: 0, Col: 39},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1370,10 +1458,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 47, Line: 0, Col: 47},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 47, Line: 0, Col: 47},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1455,10 +1548,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 83, Line: 0, Col: 83},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 83, Line: 0, Col: 83},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1549,6 +1647,8 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				TrailingSpace: SpaceVertical,
+				OpenTagRange:  Range{To: Position{Index: 70, Line: 4, Col: 1}},
+				CloseTagRange: &Range{From: Position{Index: 74, Line: 4, Col: 5}, To: Position{Index: 80, Line: 4, Col: 11}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 81, Line: 5, Col: 0},
@@ -1564,10 +1664,15 @@ func TestElementParser(t *testing.T) {
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 3, Line: 0, Col: 3},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 5, Line: 0, Col: 5},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 5, Line: 0, Col: 5},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1599,10 +1704,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 28, Line: 0, Col: 28},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 28, Line: 0, Col: 28},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1680,10 +1790,15 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				IndentAttrs: true,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 68, Line: 4, Col: 2},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 68, Line: 4, Col: 2},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1783,10 +1898,15 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				IndentAttrs: true,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 104, Line: 6, Col: 2},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 104, Line: 6, Col: 2},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -1873,6 +1993,8 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 66, Line: 4, Col: 1}},
+				CloseTagRange: &Range{From: Position{Index: 70, Line: 4, Col: 5}, To: Position{Index: 74, Line: 4, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 74, Line: 4, Col: 9},
@@ -1887,6 +2009,14 @@ func TestElementParser(t *testing.T) {
 				NameRange: Range{
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 2, Line: 0, Col: 2},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 3, Line: 0, Col: 3},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 3, Line: 0, Col: 3},
+					To:   Position{Index: 7, Line: 0, Col: 7},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
@@ -1912,6 +2042,8 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 3, Col: 3}},
+				CloseTagRange: &Range{From: Position{Index: 11, Col: 11}, To: Position{Index: 15, Col: 15}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 15, Line: 0, Col: 15},
@@ -1934,12 +2066,16 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						OpenTagRange: Range{From: Position{Index: 3, Col: 3}, To: Position{Index: 7, Col: 7}},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 7, Line: 0, Col: 7},
 						},
+						SelfClosing: true,
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 3, Col: 3}},
+				CloseTagRange: &Range{From: Position{Index: 7, Col: 7}, To: Position{Index: 11, Col: 11}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 11, Line: 0, Col: 11},
@@ -1962,12 +2098,16 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						OpenTagRange:  Range{From: Position{Index: 3, Col: 3}, To: Position{Index: 6, Col: 6}},
+						CloseTagRange: &Range{From: Position{Index: 6, Col: 6}, To: Position{Index: 10, Col: 10}},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 10, Line: 0, Col: 10},
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 3, Col: 3}},
+				CloseTagRange: &Range{From: Position{Index: 10, Col: 10}, To: Position{Index: 14, Col: 14}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 14, Line: 0, Col: 14},
@@ -2020,12 +2160,16 @@ func TestElementParser(t *testing.T) {
 								Value: " "},
 						},
 						TrailingSpace: SpaceHorizontal,
+						OpenTagRange:  Range{From: Position{Index: 4, Col: 4}, To: Position{Index: 7, Col: 7}},
+						CloseTagRange: &Range{From: Position{Index: 8, Col: 8}, To: Position{Index: 12, Col: 12}},
 						Range: Range{
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 13, Line: 0, Col: 13},
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 3, Col: 3}},
+				CloseTagRange: &Range{From: Position{Index: 13, Col: 13}, To: Position{Index: 17, Col: 17}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 17, Line: 0, Col: 17},
@@ -2048,6 +2192,8 @@ func TestElementParser(t *testing.T) {
 							From: Position{Index: 4, Line: 0, Col: 4},
 							To:   Position{Index: 5, Line: 0, Col: 5},
 						},
+						OpenTagRange:  Range{From: Position{Index: 3, Col: 3}, To: Position{Index: 6, Col: 6}},
+						CloseTagRange: &Range{From: Position{Index: 6, Col: 6}, To: Position{Index: 10, Col: 10}},
 						Range: Range{
 							From: Position{Index: 3, Line: 0, Col: 3},
 							To:   Position{Index: 10, Line: 0, Col: 10},
@@ -2066,18 +2212,24 @@ func TestElementParser(t *testing.T) {
 									From: Position{Index: 14, Line: 0, Col: 14},
 									To:   Position{Index: 15, Line: 0, Col: 15},
 								},
+								OpenTagRange: Range{From: Position{Index: 13, Col: 13}, To: Position{Index: 17, Col: 17}},
 								Range: Range{
 									From: Position{Index: 13, Line: 0, Col: 13},
 									To:   Position{Index: 17, Line: 0, Col: 17},
 								},
+								SelfClosing: true,
 							},
 						},
+						OpenTagRange:  Range{From: Position{Index: 10, Col: 10}, To: Position{Index: 13, Col: 13}},
+						CloseTagRange: &Range{From: Position{Index: 17, Col: 17}, To: Position{Index: 21, Col: 21}},
 						Range: Range{
 							From: Position{Index: 10, Line: 0, Col: 10},
 							To:   Position{Index: 21, Line: 0, Col: 21},
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 3, Col: 3}},
+				CloseTagRange: &Range{From: Position{Index: 21, Col: 21}, To: Position{Index: 25, Col: 25}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 25, Line: 0, Col: 25},
@@ -2093,6 +2245,8 @@ func TestElementParser(t *testing.T) {
 					From: Position{Index: 1, Line: 0, Col: 1},
 					To:   Position{Index: 4, Line: 0, Col: 4},
 				},
+				OpenTagRange:  Range{To: Position{Index: 5, Col: 5}},
+				CloseTagRange: &Range{From: Position{Index: 5, Col: 5}, To: Position{Index: 11, Col: 11}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 11, Line: 0, Col: 11},
@@ -2131,6 +2285,8 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 5, Col: 5}},
+				CloseTagRange: &Range{From: Position{Index: 15, Col: 15}, To: Position{Index: 21, Col: 21}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 21, Line: 0, Col: 21},
@@ -2270,10 +2426,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 140, Line: 0, Col: 140},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 140, Line: 0, Col: 140},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -2346,6 +2507,10 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 50, Line: 4, Col: 1},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 58, Line: 4, Col: 9},
@@ -2381,10 +2546,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 21, Line: 0, Col: 21},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 21, Line: 0, Col: 21},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -2461,10 +2631,15 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 57, Line: 0, Col: 57},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 57, Line: 0, Col: 57},
 				},
+				SelfClosing: true,
 			},
 		},
 		{
@@ -2510,6 +2685,8 @@ func TestElementParser(t *testing.T) {
 						},
 					},
 				},
+				OpenTagRange:  Range{To: Position{Index: 25, Col: 25}},
+				CloseTagRange: &Range{From: Position{Index: 25, Col: 25}, To: Position{Index: 31, Col: 31}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 31, Line: 0, Col: 31},
@@ -2555,6 +2732,14 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				Children: nil,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 29, Line: 1, Col: 13},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 29, Line: 1, Col: 13},
+					To:   Position{Index: 35, Line: 1, Col: 19},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 35, Line: 1, Col: 19},
@@ -2599,6 +2784,14 @@ func TestElementParser(t *testing.T) {
 					},
 				},
 				Children: nil,
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 43, Line: 0, Col: 43},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 43, Line: 0, Col: 43},
+					To:   Position{Index: 49, Line: 0, Col: 49},
+				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 49, Line: 0, Col: 49},
@@ -2633,6 +2826,14 @@ func TestElementParser(t *testing.T) {
 							To:   Position{Index: 12, Line: 0, Col: 12},
 						},
 					},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 13, Line: 0, Col: 13},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 13, Line: 0, Col: 13},
+					To:   Position{Index: 19, Line: 0, Col: 19},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
@@ -2686,6 +2887,14 @@ func TestElementParser(t *testing.T) {
 							To:   Position{Index: 28, Line: 0, Col: 28},
 						},
 					},
+				},
+				OpenTagRange: Range{
+					From: Position{Index: 0, Line: 0, Col: 0},
+					To:   Position{Index: 29, Line: 0, Col: 29},
+				},
+				CloseTagRange: &Range{
+					From: Position{Index: 29, Line: 0, Col: 29},
+					To:   Position{Index: 35, Line: 0, Col: 35},
 				},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},

--- a/parser/v2/forexpressionparser_test.go
+++ b/parser/v2/forexpressionparser_test.go
@@ -228,6 +228,8 @@ func TestForExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 36, Line: 1, Col: 5}, To: Position{Index: 41, Line: 1, Col: 10}},
+						CloseTagRange: &Range{From: Position{Index: 49, Line: 1, Col: 18}, To: Position{Index: 55, Line: 1, Col: 24}},
 						Range: Range{
 							From: Position{Index: 36, Line: 1, Col: 5},
 							To:   Position{Index: 60, Line: 2, Col: 4},
@@ -305,6 +307,8 @@ func TestForExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 35, Line: 1, Col: 5}, To: Position{Index: 40, Line: 1, Col: 10}},
+						CloseTagRange: &Range{From: Position{Index: 48, Line: 1, Col: 18}, To: Position{Index: 54, Line: 1, Col: 24}},
 						Range: Range{
 							From: Position{Index: 35, Line: 1, Col: 5},
 							To:   Position{Index: 59, Line: 2, Col: 4},

--- a/parser/v2/ifexpressionparser_test.go
+++ b/parser/v2/ifexpressionparser_test.go
@@ -84,6 +84,8 @@ func TestIfExpression(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						OpenTagRange:   Range{From: Position{Index: 12, Line: 1}, To: Position{Index: 18, Line: 1, Col: 6}},
+						CloseTagRange:  &Range{From: Position{Index: 40, Line: 3}, To: Position{Index: 47, Line: 3, Col: 7}},
 						Range: Range{
 							From: Position{Index: 12, Line: 1, Col: 0},
 							To:   Position{Index: 48, Line: 4, Col: 0},
@@ -308,6 +310,8 @@ func TestIfExpression(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						OpenTagRange:   Range{From: Position{Index: 12, Line: 1}, To: Position{Index: 18, Line: 1, Col: 6}},
+						CloseTagRange:  &Range{From: Position{Index: 40, Line: 3}, To: Position{Index: 47, Line: 3, Col: 7}},
 						Range: Range{
 							From: Position{Index: 12, Line: 1, Col: 0},
 							To:   Position{Index: 48, Line: 4, Col: 0},
@@ -508,6 +512,8 @@ func TestIfExpression(t *testing.T) {
 									},
 								},
 								TrailingSpace: SpaceVertical,
+								OpenTagRange:  Range{From: Position{Index: 29, Line: 2, Col: 6}, To: Position{Index: 34, Line: 2, Col: 11}},
+								CloseTagRange: &Range{From: Position{Index: 41, Line: 2, Col: 18}, To: Position{Index: 47, Line: 2, Col: 24}},
 								Range: Range{
 									From: Position{Index: 29, Line: 2, Col: 6},
 									To:   Position{Index: 53, Line: 3, Col: 5},

--- a/parser/v2/raw.go
+++ b/parser/v2/raw.go
@@ -21,13 +21,16 @@ func (p rawElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 	if _, ok, err = lt.Parse(pi); err != nil || !ok {
 		return
 	}
+	openTagStart := pi.PositionAt(start)
 
 	// Element name.
 	e := &RawElement{}
+	nameStartIndex := pi.Index()
 	if e.Name, ok, err = elementNameParser.Parse(pi); err != nil || !ok {
 		pi.Seek(start)
 		return
 	}
+	e.NameRange = NewRange(pi.PositionAt(nameStartIndex), pi.Position())
 
 	if e.Name != p.name {
 		pi.Seek(start)
@@ -51,6 +54,7 @@ func (p rawElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 		pi.Seek(start)
 		return
 	}
+	e.OpenTagRange = NewRange(openTagStart, pi.Position())
 
 	// Once we've got an open tag, parse anything until the end tag as the tag contents.
 	// It's going to be rendered out raw.
@@ -60,7 +64,9 @@ func (p rawElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error) {
 		return
 	}
 	// Cut the end element.
+	closeTagStart := pi.Position()
 	_, _, _ = end.Parse(pi)
+	e.CloseTagRange = NewRange(closeTagStart, pi.Position())
 
 	e.Range = NewRange(pi.PositionAt(start), pi.Position())
 	return e, true, nil

--- a/parser/v2/raw_test.go
+++ b/parser/v2/raw_test.go
@@ -22,7 +22,8 @@ func TestRawElementParser(t *testing.T) {
 			name:  "style tag",
 			input: `<style type="text/css">contents</style>`,
 			expected: &RawElement{
-				Name: "style",
+				Name:      "style",
+				NameRange: Range{From: Position{Index: 1, Col: 1}, To: Position{Index: 6, Col: 6}},
 				Attributes: []Attribute{
 					&ConstantAttribute{
 						Value: "text/css",
@@ -43,7 +44,9 @@ func TestRawElementParser(t *testing.T) {
 						},
 					},
 				},
-				Contents: "contents",
+				Contents:      "contents",
+				OpenTagRange:  Range{To: Position{Index: 23, Col: 23}},
+				CloseTagRange: Range{From: Position{Index: 31, Col: 31}, To: Position{Index: 39, Col: 39}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 39, Line: 0, Col: 39},
@@ -54,7 +57,8 @@ func TestRawElementParser(t *testing.T) {
 			name:  "style tag containing mismatched braces",
 			input: `<style type="text/css">` + ignoredContent + "</style>",
 			expected: &RawElement{
-				Name: "style",
+				Name:      "style",
+				NameRange: Range{From: Position{Index: 1, Col: 1}, To: Position{Index: 6, Col: 6}},
 				Attributes: []Attribute{
 					&ConstantAttribute{
 						Value: "text/css",
@@ -75,7 +79,9 @@ func TestRawElementParser(t *testing.T) {
 						},
 					},
 				},
-				Contents: ignoredContent,
+				Contents:      ignoredContent,
+				OpenTagRange:  Range{To: Position{Index: 23, Col: 23}},
+				CloseTagRange: Range{From: Position{Index: 44, Line: 3, Col: 1}, To: Position{Index: 52, Line: 3, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 52, Line: 3, Col: 9},

--- a/parser/v2/scriptparser.go
+++ b/parser/v2/scriptparser.go
@@ -26,6 +26,7 @@ func (p scriptElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error)
 	if _, ok, err = lt.Parse(pi); err != nil || !ok {
 		return
 	}
+	openTagStart := pi.PositionAt(start)
 
 	// Element name.
 	e := &ScriptElement{}
@@ -56,6 +57,7 @@ func (p scriptElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error)
 		pi.Seek(start)
 		return n, false, parse.Error("<script>: unclosed element - missing '>'", pi.Position())
 	}
+	e.OpenTagRange = NewRange(openTagStart, pi.Position())
 
 	// If there's a type attribute and it's not a JS attribute (e.g. text/javascript), we need to parse the contents as raw text.
 	if !hasJavaScriptType(e.Attributes) {
@@ -66,8 +68,9 @@ func (p scriptElementParser) Parse(pi *parse.Input) (n Node, ok bool, err error)
 		e.Contents = append(e.Contents, NewScriptContentsScriptCode(contents))
 
 		// Cut the end element.
+		closeTagStart := pi.Position()
 		_, _, _ = jsEndTag.Parse(pi)
-
+		e.CloseTagRange = NewRange(closeTagStart, pi.Position())
 		e.Range = NewRange(pi.PositionAt(start), pi.Position())
 		return e, true, nil
 	}
@@ -89,14 +92,17 @@ loop:
 		//  - \ - Start of an escape sequence, we can just take the value.
 		//  - Anything else - Add it to the script.
 
+		closeTagStartIndex := pi.Index()
 		_, ok, err = jsEndTag.Parse(pi)
 		if err != nil {
 			return nil, false, err
 		}
 		if ok {
+			e.CloseTagRange = NewRange(pi.PositionAt(closeTagStartIndex), pi.Position())
 			// We've reached the end of the script.
 			break loop
 		}
+		pi.Seek(closeTagStartIndex)
 
 		_, ok, err = endTagStart.Parse(pi)
 		if err != nil {

--- a/parser/v2/scriptparser_test.go
+++ b/parser/v2/scriptparser_test.go
@@ -71,6 +71,8 @@ func TestScriptElementParser(t *testing.T) {
 			name:  "no content",
 			input: `<script></script>`,
 			expected: &ScriptElement{
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 8, Col: 8}, To: Position{Index: 17, Col: 17}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 17, Line: 0, Col: 17},
@@ -104,6 +106,8 @@ func TestScriptElementParser(t *testing.T) {
 				Contents: []ScriptContents{
 					NewScriptContentsScriptCode("dim x = 1"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 24, Col: 24}},
+				CloseTagRange: Range{From: Position{Index: 33, Col: 33}, To: Position{Index: 42, Col: 42}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 42, Line: 0, Col: 42},
@@ -129,6 +133,8 @@ func TestScriptElementParser(t *testing.T) {
 						},
 					}, false),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 18, Col: 18}, To: Position{Index: 27, Col: 27}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 27, Line: 0, Col: 27},
@@ -171,6 +177,8 @@ func TestScriptElementParser(t *testing.T) {
 						},
 					}, false),
 				},
+				OpenTagRange:  Range{To: Position{Index: 31, Col: 31}},
+				CloseTagRange: Range{From: Position{Index: 41, Col: 41}, To: Position{Index: 50, Col: 50}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 50, Line: 0, Col: 50},
@@ -213,6 +221,8 @@ func TestScriptElementParser(t *testing.T) {
 						},
 					}, false),
 				},
+				OpenTagRange:  Range{To: Position{Index: 22, Col: 22}},
+				CloseTagRange: Range{From: Position{Index: 32, Col: 32}, To: Position{Index: 41, Col: 41}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 41, Line: 0, Col: 41},
@@ -255,6 +265,8 @@ func TestScriptElementParser(t *testing.T) {
 						},
 					}, false),
 				},
+				OpenTagRange:  Range{To: Position{Index: 26, Col: 26}},
+				CloseTagRange: Range{From: Position{Index: 36, Col: 36}, To: Position{Index: 45, Col: 45}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 45, Line: 0, Col: 45},
@@ -284,6 +296,8 @@ func TestScriptElementParser(t *testing.T) {
 						},
 					}, false),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 20, Line: 2}, To: Position{Index: 29, Line: 2, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 29, Line: 2, Col: 9},
@@ -311,6 +325,8 @@ func TestScriptElementParser(t *testing.T) {
 					}, true),
 					NewScriptContentsScriptCode("';"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 29, Col: 29}, To: Position{Index: 38, Col: 38}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 38, Line: 0, Col: 38},
@@ -338,6 +354,8 @@ func TestScriptElementParser(t *testing.T) {
 					}, true),
 					NewScriptContentsScriptCode("\";"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 29, Col: 29}, To: Position{Index: 38, Col: 38}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 38, Line: 0, Col: 38},
@@ -368,6 +386,8 @@ to see if it works";</script>`,
 					}, true),
 					NewScriptContentsScriptCode("\\\nto see if it works\";"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 67, Line: 2, Col: 20}, To: Position{Index: 76, Line: 2, Col: 29}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 76, Line: 2, Col: 29},
@@ -395,6 +415,8 @@ to see if it works";</script>`,
 					}, true),
 					NewScriptContentsScriptCode("`;"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 29, Col: 29}, To: Position{Index: 38, Col: 38}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 38, Line: 0, Col: 38},
@@ -411,6 +433,8 @@ to see if it works";</script>`,
 					NewScriptContentsScriptCode("\n"),
 					NewScriptContentsScriptCode("// {{ name }}\n"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 23, Line: 2}, To: Position{Index: 32, Line: 2, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 32, Line: 2, Col: 9},
@@ -427,6 +451,8 @@ const category = path.split('/')[2]; // example comment
 					NewScriptContentsScriptCode("\nconst category = path.split('/')[2]; "),
 					NewScriptContentsScriptCode("// example comment\n"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 65, Line: 2}, To: Position{Index: 74, Line: 2, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 74, Line: 2, Col: 9},
@@ -445,6 +471,8 @@ but it's commented out */
 					NewScriptContentsScriptCode("\n"),
 					NewScriptContentsScriptCode("/* There's some content\n{{ name }}\nbut it's commented out */\n"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 70, Line: 4}, To: Position{Index: 79, Line: 4, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 79, Line: 4, Col: 9},
@@ -477,6 +505,8 @@ set tier_1 to #tier-1's value
 				Contents: []ScriptContents{
 					NewScriptContentsScriptCode("\nset tier_1 to #tier-1's value\n"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 32, Col: 32}},
+				CloseTagRange: Range{From: Position{Index: 63, Line: 2}, To: Position{Index: 72, Line: 2, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 72, Line: 2, Col: 9},
@@ -506,6 +536,8 @@ const result = call(1000 / 10, {{ data }}, 1000 / 10);
 					}, false),
 					NewScriptContentsScriptCode(", 1000 / 10);\n"),
 				},
+				OpenTagRange:  Range{To: Position{Index: 8, Col: 8}},
+				CloseTagRange: Range{From: Position{Index: 64, Line: 2}, To: Position{Index: 73, Line: 2, Col: 9}},
 				Range: Range{
 					From: Position{Index: 0, Line: 0, Col: 0},
 					To:   Position{Index: 73, Line: 2, Col: 9},

--- a/parser/v2/switchexpressionparser_test.go
+++ b/parser/v2/switchexpressionparser_test.go
@@ -139,6 +139,8 @@ default:
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								OpenTagRange:   Range{From: Position{Index: 29, Line: 2, Col: 1}, To: Position{Index: 35, Line: 2, Col: 7}},
+								CloseTagRange:  &Range{From: Position{Index: 59, Line: 4, Col: 1}, To: Position{Index: 66, Line: 4, Col: 8}},
 								Range: Range{
 									From: Position{Index: 29, Line: 2, Col: 1},
 									To:   Position{Index: 67, Line: 5, Col: 0},
@@ -240,6 +242,8 @@ default:
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								OpenTagRange:   Range{From: Position{Index: 36, Line: 2}, To: Position{Index: 42, Line: 2, Col: 6}},
+								CloseTagRange:  &Range{From: Position{Index: 64, Line: 4}, To: Position{Index: 71, Line: 4, Col: 7}},
 								Range: Range{
 									From: Position{Index: 36, Line: 2, Col: 0},
 									To:   Position{Index: 72, Line: 5, Col: 0},

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -202,6 +202,8 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 26, Line: 1}, To: Position{Index: 32, Line: 1, Col: 6}},
+						CloseTagRange: &Range{From: Position{Index: 50, Line: 1, Col: 24}, To: Position{Index: 57, Line: 1, Col: 31}},
 						Range: Range{
 							From: Position{Index: 26, Line: 1, Col: 0},
 							To:   Position{Index: 58, Line: 2, Col: 0},
@@ -264,6 +266,8 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceHorizontal,
+						OpenTagRange:  Range{From: Position{Index: 26, Col: 26}, To: Position{Index: 32, Col: 32}},
+						CloseTagRange: &Range{From: Position{Index: 50, Col: 50}, To: Position{Index: 57, Col: 57}},
 						Range: Range{
 							From: Position{Index: 26, Line: 0, Col: 26},
 							To:   Position{Index: 58, Line: 0, Col: 58},
@@ -390,6 +394,8 @@ func TestTemplateParser(t *testing.T) {
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								OpenTagRange:   Range{From: Position{Index: 54, Line: 3, Col: 2}, To: Position{Index: 60, Line: 3, Col: 8}},
+								CloseTagRange:  &Range{From: Position{Index: 83, Line: 5, Col: 2}, To: Position{Index: 90, Line: 5, Col: 9}},
 								Range: Range{
 									From: Position{Index: 54, Line: 3, Col: 2},
 									To:   Position{Index: 91, Line: 6, Col: 0},
@@ -398,6 +404,8 @@ func TestTemplateParser(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						OpenTagRange:   Range{From: Position{Index: 26, Line: 1}, To: Position{Index: 31, Line: 1, Col: 5}},
+						CloseTagRange:  &Range{From: Position{Index: 91, Line: 6}, To: Position{Index: 97, Line: 6, Col: 6}},
 						Range: Range{
 							From: Position{Index: 26, Line: 1, Col: 0},
 							To:   Position{Index: 98, Line: 7, Col: 0},
@@ -524,6 +532,8 @@ func TestTemplateParser(t *testing.T) {
 								},
 								IndentChildren: true,
 								TrailingSpace:  SpaceVertical,
+								OpenTagRange:   Range{From: Position{Index: 41, Line: 2, Col: 2}, To: Position{Index: 47, Line: 2, Col: 8}},
+								CloseTagRange:  &Range{From: Position{Index: 72, Line: 4, Col: 2}, To: Position{Index: 79, Line: 4, Col: 9}},
 								Range: Range{
 									From: Position{Index: 41, Line: 2, Col: 2},
 									To:   Position{Index: 81, Line: 5, Col: 1},
@@ -636,10 +646,12 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 27, Line: 1, Col: 1}, To: Position{Index: 58, Line: 1, Col: 32}},
 						Range: Range{
 							From: Position{Index: 27, Line: 1, Col: 1},
 							To:   Position{Index: 60, Line: 2, Col: 1},
 						},
+						SelfClosing: true,
 					},
 					&Element{
 						Name: "input",
@@ -686,10 +698,12 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 60, Line: 2, Col: 1}, To: Position{Index: 91, Line: 2, Col: 32}},
 						Range: Range{
 							From: Position{Index: 60, Line: 2, Col: 1},
 							To:   Position{Index: 92, Line: 3, Col: 0},
 						},
+						SelfClosing: true,
 					},
 				},
 			},
@@ -863,6 +877,8 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 13, Line: 1, Col: 1}, To: Position{Index: 25, Line: 1, Col: 13}},
+						CloseTagRange: &Range{From: Position{Index: 52, Line: 1, Col: 40}, To: Position{Index: 56, Line: 1, Col: 44}},
 						Range: Range{
 							From: Position{Index: 13, Line: 1, Col: 1},
 							To:   Position{Index: 57, Line: 2, Col: 0},
@@ -924,6 +940,14 @@ func TestTemplateParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange: Range{
+							From: Position{Index: 13, Line: 1, Col: 1},
+							To:   Position{Index: 18, Line: 1, Col: 6},
+						},
+						CloseTagRange: &Range{
+							From: Position{Index: 31, Line: 1, Col: 19},
+							To:   Position{Index: 37, Line: 1, Col: 25},
+						},
 						Range: Range{
 							From: Position{Index: 13, Line: 1, Col: 1},
 							To:   Position{Index: 38, Line: 2, Col: 0},
@@ -1280,6 +1304,8 @@ func TestTemplateParser(t *testing.T) {
 						},
 						IndentChildren: true,
 						TrailingSpace:  SpaceVertical,
+						OpenTagRange:   Range{From: Position{Index: 42, Line: 1, Col: 2}, To: Position{Index: 64, Line: 1, Col: 24}},
+						CloseTagRange:  &Range{From: Position{Index: 86, Line: 3, Col: 2}, To: Position{Index: 93, Line: 3, Col: 9}},
 						Range: Range{
 							From: Position{Index: 42, Line: 1, Col: 2},
 							To:   Position{Index: 94, Line: 4, Col: 0},
@@ -1326,6 +1352,7 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 19, Line: 1, Col: 4},
 						},
 						TrailingSpace: SpaceNone,
+						OpenTagRange:  Range{From: Position{Index: 16, Line: 1, Col: 1}, To: Position{Index: 20, Line: 1, Col: 5}},
 						Range: Range{
 							From: Position{Index: 16, Line: 1, Col: 1},
 							To:   Position{Index: 25, Line: 1, Col: 10},
@@ -1338,6 +1365,7 @@ func TestTemplateParser(t *testing.T) {
 							To:   Position{Index: 28, Line: 1, Col: 13},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 25, Line: 1, Col: 10}, To: Position{Index: 29, Line: 1, Col: 14}},
 						Range: Range{
 							From: Position{Index: 25, Line: 1, Col: 10},
 							To:   Position{Index: 30, Line: 2, Col: 0},

--- a/parser/v2/templelementparser_test.go
+++ b/parser/v2/templelementparser_test.go
@@ -209,10 +209,12 @@ func TestTemplElementExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 19, Line: 1, Col: 3}, To: Position{Index: 39, Line: 1, Col: 23}},
 						Range: Range{
 							From: Position{Index: 19, Line: 1, Col: 3},
 							To:   Position{Index: 42, Line: 2, Col: 2},
 						},
+						SelfClosing: true,
 					},
 				},
 				Range: Range{
@@ -539,6 +541,8 @@ func TestTemplElementExpressionParser(t *testing.T) {
 							},
 						},
 						TrailingSpace: SpaceVertical,
+						OpenTagRange:  Range{From: Position{Index: 38, Line: 1, Col: 2}, To: Position{Index: 43, Line: 1, Col: 7}},
+						CloseTagRange: &Range{From: Position{Index: 48, Line: 1, Col: 12}, To: Position{Index: 54, Line: 1, Col: 18}},
 						Range: Range{
 							From: Position{Index: 38, Line: 1, Col: 2},
 							To:   Position{Index: 55, Line: 2, Col: 0},

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -500,6 +500,9 @@ type Element struct {
 	IndentChildren bool
 	TrailingSpace  TrailingSpace
 	NameRange      Range
+	OpenTagRange   Range
+	CloseTagRange  *Range
+	SelfClosing    bool
 	Range          Range
 }
 
@@ -731,9 +734,11 @@ type ScriptContents struct {
 }
 
 type ScriptElement struct {
-	Attributes []Attribute
-	Contents   []ScriptContents
-	Range      Range
+	Attributes    []Attribute
+	Contents      []ScriptContents
+	OpenTagRange  Range
+	CloseTagRange Range
+	Range         Range
 }
 
 func (se *ScriptElement) IsNode() bool { return true }
@@ -795,10 +800,13 @@ func writeStrings(w io.Writer, ss ...string) error {
 }
 
 type RawElement struct {
-	Name       string
-	Attributes []Attribute
-	Contents   string
-	Range      Range
+	Name          string
+	Attributes    []Attribute
+	Contents      string
+	NameRange     Range
+	OpenTagRange  Range
+	CloseTagRange Range
+	Range         Range
 }
 
 func (e *RawElement) IsNode() bool { return true }


### PR DESCRIPTION
Adds `OpenTagRange`, `CloseTagRange`, and `SelfClosing` to element types. Also adds `NameRange` to `RawElement`.

Continues the initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302, #1335, #1336, #1337, #1338, #1340, #1341, #1347, #1348, #1350, and #1383.