### PR TITLE
Fix JavaScript function name validation

### DIFF
--- a/js_test.go
+++ b/js_test.go
@@ -157,7 +157,39 @@ func TestJSFunctionNameRegexp(t *testing.T) {
 			expected: true,
 		},
 		{
+			input:    "a",
+			expected: true,
+		},
+		{
+			input:    "$",
+			expected: true,
+		},
+		{
+			input:    "_",
+			expected: true,
+		},
+		{
+			input:    "$._",
+			expected: true,
+		},
+		{
 			input:    "console.log('hello')",
+			expected: false,
+		},
+		{
+			input:    "console.",
+			expected: false,
+		},
+		{
+			input:    ".log",
+			expected: false,
+		},
+		{
+			input:    "console..log",
+			expected: false,
+		},
+		{
+			input:    "1alert",
 			expected: false,
 		},
 		{

--- a/scripttemplate.go
+++ b/scripttemplate.go
@@ -147,4 +147,4 @@ func jsonEncodeParam(param any) string {
 }
 
 // isValidJSFunctionName returns true if the given string is a valid JavaScript function name, e.g. console.log, alert, etc.
-var jsFunctionName = regexp.MustCompile(`^([$_a-zA-Z][$_a-zA-Z0-9]+\.?)+$`)
+var jsFunctionName = regexp.MustCompile(`^[$_a-zA-Z][$_a-zA-Z0-9]*(\.[$_a-zA-Z][$_a-zA-Z0-9]*)*$`)


### PR DESCRIPTION
Fixes JavaScript function name validation used by JSFuncCall.

The previous regexp rejected valid one-character identifiers like a, $, and _, while allowing invalid dotted names such as console.. This updates the validation to accept dot-separated JavaScript identifiers and reject empty, leading, or trailing member segments.

Tests

`go test -run 'TestJS(FunctionNameRegexp|FuncCall)' .`