### PR TITLE
examples/suspense: buffer the slot channel so producers can't leak

### DIFF
--- a/examples/suspense/main.templ
+++ b/examples/suspense/main.templ
@@ -9,7 +9,9 @@ import (
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Create a channel to send deferred component renders to the template.
-		data := make(chan SlotContents)
+		// Buffer for the known 3 slots so a goroutine never blocks on send if
+		// the client disconnects before the template finishes reading.
+		data := make(chan SlotContents, 3)
 
 		// We know there are 3 slots, so start a WaitGroup.
 		var wg sync.WaitGroup

--- a/examples/suspense/main_templ.go
+++ b/examples/suspense/main_templ.go
@@ -16,7 +16,9 @@ import (
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Create a channel to send deferred component renders to the template.
-		data := make(chan SlotContents)
+		// Buffer for the known 3 slots so a goroutine never blocks on send if
+		// the client disconnects before the template finishes reading.
+		data := make(chan SlotContents, 3)
 
 		// We know there are 3 slots, so start a WaitGroup.
 		var wg sync.WaitGroup


### PR DESCRIPTION
From #1352: the suspense example creates an unbuffered channel for the three deferred slots. Each producer goroutine sends one `SlotContents` value to it, and the `Page` template reads them via `for sc := range data`. If the client disconnects (or `templ.WithStreaming()` aborts) before the for-range loop has read every value, the producer goroutines block on send forever and the goroutines (plus the `templ.Component` they captured) stay pinned for the life of the process.

The `WaitGroup` already states the producer count up front (three slots, `wg.Add(3)`), so the bound is known. Buffer the channel by 3, then a producer always completes even if no one is reading.

Updated the templ source and the generated `main_templ.go`; running `templ generate` again won't change anything else.

Closes #1352.
