### PR TITLE
fix: narrow ResolveAttributeValue to stringable | ComponentScript types

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -678,6 +678,10 @@ type stringable interface {
 	ints | uints | floats | complexNumbers | ~string | ~bool
 }
 
+type attributeValue interface {
+	ints | uints | floats | complexNumbers | ~string | ~bool | ComponentScript
+}
+
 // JoinStringErrs joins an optional list of errors.
 func JoinStringErrs[T stringable](s T, errs ...error) (string, error) {
 	return fmt.Sprint(s), errors.Join(errs...)
@@ -687,11 +691,11 @@ func JoinStringErrs[T stringable](s T, errs ...error) (string, error) {
 // HTML-escaped string suitable for use in an attribute value. It handles
 // ComponentScript values by returning their Call field (already escaped),
 // and falls back to HTML-escaping fmt.Sprint for other types.
-func ResolveAttributeValue(v any, errs ...error) (string, error) {
+func ResolveAttributeValue[T attributeValue](v T, errs ...error) (string, error) {
 	if err := errors.Join(errs...); err != nil {
 		return "", err
 	}
-	switch v := v.(type) {
+	switch v := any(v).(type) {
 	case ComponentScript:
 		return v.Call, nil
 	case string:

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -628,43 +628,41 @@ func TestNonce(t *testing.T) {
 func TestResolveAttributeValue(t *testing.T) {
 	tests := []struct {
 		name     string
-		v        any
-		errs     []error
+		run      func() (string, error)
 		expected string
 		wantErr  bool
 	}{
 		{
 			name:     "string value is HTML-escaped",
-			v:        `<script>alert("xss")</script>`,
+			run:      func() (string, error) { return templ.ResolveAttributeValue(`<script>alert("xss")</script>`) },
 			expected: `&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;`,
 		},
 		{
 			name:     "integer value is converted to string",
-			v:        42,
+			run:      func() (string, error) { return templ.ResolveAttributeValue(42) },
 			expected: "42",
 		},
 		{
 			name:     "bool value is converted to string",
-			v:        true,
+			run:      func() (string, error) { return templ.ResolveAttributeValue(true) },
 			expected: "true",
 		},
 		{
 			name: "ComponentScript returns pre-escaped Call field",
-			v: templ.ComponentScript{
-				Call: `alert(&#34;Hello&#34;)`,
+			run: func() (string, error) {
+				return templ.ResolveAttributeValue(templ.ComponentScript{Call: `alert(&#34;Hello&#34;)`})
 			},
 			expected: `alert(&#34;Hello&#34;)`,
 		},
 		{
 			name:    "error is returned",
-			v:       "value",
-			errs:    []error{errors.New("test error")},
+			run:     func() (string, error) { return templ.ResolveAttributeValue("value", errors.New("test error")) },
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := templ.ResolveAttributeValue(tt.v, tt.errs...)
+			got, err := tt.run()
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")


### PR DESCRIPTION
See https://github.com/a-h/templ/pull/1375#discussion_r3263060566. The prior change relaxed the types that could be serialized into attributes. This restores the earlier behavior while continuing to support ComponentScript serialization