### PR TITLE
feat: add -no-format flag to skip formatting on generated output

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -103,6 +103,7 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 		cmd.Args.KeepOrphanedFiles,
 		cmd.Args.FileWriter,
 		cmd.Args.Lazy,
+		cmd.Args.NoFormat,
 	)
 
 	// If we're processing a single file, don't bother setting up the channels/multithreaing.

--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -75,6 +75,7 @@ func NewFSEventHandler(
 	keepOrphanedFiles bool,
 	fileWriter FileWriterFunc,
 	lazy bool,
+	noFormat bool,
 ) *FSEventHandler {
 	if !path.IsAbs(dir) {
 		dir, _ = filepath.Abs(dir)
@@ -92,6 +93,7 @@ func NewFSEventHandler(
 		keepOrphanedFiles:     keepOrphanedFiles,
 		writer:                fileWriter,
 		lazy:                  lazy,
+		noFormat:              noFormat,
 	}
 	return fseh
 }
@@ -111,6 +113,7 @@ type FSEventHandler struct {
 	keepOrphanedFiles     bool
 	writer                FileWriterFunc
 	lazy                  bool
+	noFormat              bool
 }
 
 type GenerateResult struct {
@@ -234,10 +237,15 @@ func (h *FSEventHandler) generate(ctx context.Context, fileName string) (result 
 		return GenerateResult{}, nil, fmt.Errorf("%s generation error: %w", fileName, err)
 	}
 
-	formattedGoCode, err := format.Source(b.Bytes())
-	if err != nil {
-		err = remapErrorList(err, generatorOutput.SourceMap, fileName)
-		return GenerateResult{}, nil, fmt.Errorf("%s source formatting error %w", fileName, err)
+	var formattedGoCode []byte
+	if h.noFormat {
+		formattedGoCode = b.Bytes()
+	} else {
+		formattedGoCode, err = format.Source(b.Bytes())
+		if err != nil {
+			err = remapErrorList(err, generatorOutput.SourceMap, fileName)
+			return GenerateResult{}, nil, fmt.Errorf("%s source formatting error %w", fileName, err)
+		}
 	}
 
 	// Hash output, and write out the file if the goCodeHash has changed.

--- a/cmd/templ/generatecmd/main.go
+++ b/cmd/templ/generatecmd/main.go
@@ -58,6 +58,10 @@ Args:
     Port to run the pprof server on.
   -keep-orphaned-files
     Keeps orphaned generated templ files. (default false)
+  -no-format
+    Skips formatting of generated Go code. Source map positions will be
+    consistent with the unformatted output, which is useful for programmatic
+    consumers such as coverage tools and build system integrations (e.g. Bazel).
   -check
     Checks that generated files are up to date, without writing changes.
     Returns a non-zero exit code if any files need regenerating.
@@ -111,6 +115,7 @@ func NewArguments(stdout, stderr io.Writer, args []string) (cmdArgs Arguments, l
 	cmd.IntVar(&cmdArgs.WorkerCount, "w", runtime.NumCPU(), "")
 	cmd.IntVar(&cmdArgs.PPROFPort, "pprof", 0, "")
 	cmd.BoolVar(&cmdArgs.KeepOrphanedFiles, "keep-orphaned-files", false, "")
+	cmd.BoolVar(&cmdArgs.NoFormat, "no-format", false, "")
 	cmd.BoolVar(&cmdArgs.Lazy, "lazy", false, "")
 	cmd.BoolVar(&cmdArgs.Check, "check", false, "")
 	verboseFlag := cmd.Bool("v", false, "")
@@ -185,6 +190,7 @@ type Arguments struct {
 	// PPROFPort is the port to run the pprof server on.
 	PPROFPort         int
 	KeepOrphanedFiles bool
+	NoFormat          bool
 	Lazy              bool
 }
 

--- a/cmd/templ/generatecmd/test-eventhandler/eventhandler_test.go
+++ b/cmd/templ/generatecmd/test-eventhandler/eventhandler_test.go
@@ -54,7 +54,7 @@ templ hello() {
 	}
 
 	dir := filepath.Dir(templFileName)
-	fseh := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false)
+	fseh := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false, false)
 
 	t.Run("first generation writes the Go file", func(t *testing.T) {
 		result, err := fseh.HandleEvent(context.Background(), fsnotify.Event{Name: templFileName, Op: fsnotify.Create})
@@ -94,7 +94,7 @@ templ hello() {
 			t.Fatalf("failed to update file times: %v", err)
 		}
 
-		freshHandler := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false)
+		freshHandler := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false, false)
 		result, err := freshHandler.HandleEvent(context.Background(), fsnotify.Event{Name: templFileName, Op: fsnotify.Create})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -123,7 +123,7 @@ templ hello() {
 			t.Fatalf("failed to write changed templ content: %v", err)
 		}
 
-		freshHandler := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false)
+		freshHandler := generatecmd.NewFSEventHandler(log, dir, false, []generator.GenerateOpt{}, false, false, generatecmd.FileWriter, false, false)
 		result, err := freshHandler.HandleEvent(context.Background(), fsnotify.Event{Name: templFileName, Op: fsnotify.Create})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -173,7 +173,7 @@ func TestErrorLocationMapping(t *testing.T) {
 
 	slog := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	var fw generatecmd.FileWriterFunc
-	fseh := generatecmd.NewFSEventHandler(slog, ".", false, []generator.GenerateOpt{}, false, false, fw, false)
+	fseh := generatecmd.NewFSEventHandler(slog, ".", false, []generator.GenerateOpt{}, false, false, fw, false, false)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When set, the generator writes raw output directly without the format step. Source map positions are then consistent with the generated file content, which enables programmatic usage of sourcemap information (coverage tooling, stack trace sourcemapping, etc).

The LSP already works this way — it never formats before caching the source map. This flag lets build systems match that behavior.