### PR TITLE
feat: add ranges to DocType nodes

### DIFF
--- a/cmd/templ/generatecmd/proxy/proxy_test.go
+++ b/cmd/templ/generatecmd/proxy/proxy_test.go
@@ -868,7 +868,7 @@ var y = true && false;
 alert("test");
 </script>`)
 		for i := range 50 {
-			inputBuilder.WriteString(fmt.Sprintf("<div>%d padding</div>\n", i))
+			fmt.Fprintf(&inputBuilder, "<div>%d padding</div>\n", i)
 		}
 		inputBuilder.WriteString("</body></html>")
 		input := inputBuilder.String()

--- a/internal/format/attributes.go
+++ b/internal/format/attributes.go
@@ -57,7 +57,7 @@ func Attributes(children []parser.Node, prettierCommand string) error {
 	// Build synthetic HTML: one <div> per attribute.
 	var sb strings.Builder
 	for i, e := range entries {
-		sb.WriteString(fmt.Sprintf(`<div data-templ-id="%d" %s="%s"></div>`, i, e.key, html.EscapeString(e.attr.Value)))
+		fmt.Fprintf(&sb, `<div data-templ-id="%d" %s="%s"></div>`, i, e.key, html.EscapeString(e.attr.Value))
 		sb.WriteByte('\n')
 	}
 

--- a/internal/prettier/prettier.go
+++ b/internal/prettier/prettier.go
@@ -94,7 +94,7 @@ func Element(name string, typeAttrValue string, content string, depth int, prett
 	// Add divs to the start and end of the script to ensure that prettier formats the content with
 	// correct indentation.
 	for i := range depth {
-		indentationWrapper.WriteString(fmt.Sprintf("<div data-templ-depth=\"%d\">", i))
+		fmt.Fprintf(&indentationWrapper, "<div data-templ-depth=\"%d\">", i)
 	}
 
 	// Write start tag with type attribute if present.

--- a/parser/v2/doctypeparser.go
+++ b/parser/v2/doctypeparser.go
@@ -14,20 +14,30 @@ var docType = parse.Func(func(pi *parse.Input) (n Node, ok bool, err error) {
 	if _, ok, err = doctypeStartParser.Parse(pi); err != nil || !ok {
 		return
 	}
+	// The parser consumes the required separator space, but OpenRange covers only the opener.
+	openEnd := pi.PositionAt(pi.Index() - 1)
 
-	// Once a doctype has started, take everything until the end.
-	r := &DocType{}
+	r := &DocType{
+		OpenRange: NewRange(start, openEnd),
+	}
+
+	valueStart := pi.Position()
 	if r.Value, ok, err = stringUntilLtOrGt.Parse(pi); err != nil || !ok {
 		err = parse.Error("unclosed DOCTYPE", start)
 		return
 	}
+	valueEnd := pi.Position()
+	r.ValueRange = NewRange(valueStart, valueEnd)
 
-	// Clear the final '>'.
+	closeStart := pi.Position()
 	if _, ok, err = gt.Parse(pi); err != nil || !ok {
 		err = parse.Error("unclosed DOCTYPE", start)
 		return
 	}
-	r.Range = NewRange(start, pi.Position())
+	closeEnd := pi.Position()
+	r.CloseRange = NewRange(closeStart, closeEnd)
+
+	r.Range = NewRange(start, closeEnd)
 
 	return r, true, nil
 })

--- a/parser/v2/doctypeparser_test.go
+++ b/parser/v2/doctypeparser_test.go
@@ -22,6 +22,18 @@ func TestDocTypeParser(t *testing.T) {
 					To:   Position{Index: 15, Line: 0, Col: 15},
 				},
 				Value: "html",
+				OpenRange: Range{
+					From: Position{},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				ValueRange: Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 14, Line: 0, Col: 14},
+				},
+				CloseRange: Range{
+					From: Position{Index: 14, Line: 0, Col: 14},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
 			},
 		},
 		{
@@ -33,6 +45,41 @@ func TestDocTypeParser(t *testing.T) {
 					To:   Position{Index: 15, Line: 0, Col: 15},
 				},
 				Value: "html",
+				OpenRange: Range{
+					From: Position{},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				ValueRange: Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 14, Line: 0, Col: 14},
+				},
+				CloseRange: Range{
+					From: Position{Index: 14, Line: 0, Col: 14},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
+			},
+		},
+		{
+			name:  "HTML 5 doctype - extra space",
+			input: `<!DOCTYPE  html>`,
+			expected: &DocType{
+				Range: Range{
+					From: Position{},
+					To:   Position{Index: 16, Line: 0, Col: 16},
+				},
+				Value: " html",
+				OpenRange: Range{
+					From: Position{},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				ValueRange: Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 15, Line: 0, Col: 15},
+				},
+				CloseRange: Range{
+					From: Position{Index: 15, Line: 0, Col: 15},
+					To:   Position{Index: 16, Line: 0, Col: 16},
+				},
 			},
 		},
 		{
@@ -44,6 +91,18 @@ func TestDocTypeParser(t *testing.T) {
 					To:   Position{Index: 102, Line: 0, Col: 102},
 				},
 				Value: `HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"`,
+				OpenRange: Range{
+					From: Position{},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				ValueRange: Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 101, Line: 0, Col: 101},
+				},
+				CloseRange: Range{
+					From: Position{Index: 101, Line: 0, Col: 101},
+					To:   Position{Index: 102, Line: 0, Col: 102},
+				},
 			},
 		},
 		{
@@ -55,6 +114,18 @@ func TestDocTypeParser(t *testing.T) {
 					To:   Position{Index: 97, Line: 0, Col: 97},
 				},
 				Value: `html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"`,
+				OpenRange: Range{
+					From: Position{},
+					To:   Position{Index: 9, Line: 0, Col: 9},
+				},
+				ValueRange: Range{
+					From: Position{Index: 10, Line: 0, Col: 10},
+					To:   Position{Index: 96, Line: 0, Col: 96},
+				},
+				CloseRange: Range{
+					From: Position{Index: 96, Line: 0, Col: 96},
+					To:   Position{Index: 97, Line: 0, Col: 97},
+				},
 			},
 		},
 	}

--- a/parser/v2/templateparser_test.go
+++ b/parser/v2/templateparser_test.go
@@ -739,7 +739,10 @@ func TestTemplateParser(t *testing.T) {
 							From: Position{Index: 15, Line: 1, Col: 0},
 							To:   Position{Index: 30, Line: 1, Col: 15},
 						},
-						Value: "html",
+						Value:      "html",
+						OpenRange:  Range{From: Position{Index: 15, Line: 1}, To: Position{Index: 24, Line: 1, Col: 9}},
+						ValueRange: Range{From: Position{Index: 25, Line: 1, Col: 10}, To: Position{Index: 29, Line: 1, Col: 14}},
+						CloseRange: Range{From: Position{Index: 29, Line: 1, Col: 14}, To: Position{Index: 30, Line: 1, Col: 15}},
 					},
 					&Whitespace{Range: Range{
 						From: Position{

--- a/parser/v2/types.go
+++ b/parser/v2/types.go
@@ -364,8 +364,11 @@ func (c *ExpressionCSSProperty) Visit(v Visitor) error {
 
 // <!DOCTYPE html>
 type DocType struct {
-	Range Range
-	Value string
+	Range      Range
+	Value      string
+	OpenRange  Range
+	ValueRange Range
+	CloseRange Range
 }
 
 func (dt *DocType) IsNode() bool { return true }

--- a/runtime.go
+++ b/runtime.go
@@ -554,7 +554,7 @@ func ptrValue(v any) any {
 		return nil
 	}
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Pointer {
 		return v
 	}
 	if rv.IsNil() {


### PR DESCRIPTION
Adds `OpenRange`, `ValueRange`, and `CloseRange` to the parser's `DocType` nodes.

For example, with `<!DOCTYPE html>`:

- `OpenRange`: `<!DOCTYPE`
- `ValueRange`: `html`
- `CloseRange`: `>`

The separator space remains covered only by the node `Range`.

Continues the initiative of adding `Range` to all AST nodes for the benefit of external linting tools, which started in #1225 and was originally discussed in https://github.com/a-h/templ/discussions/586.

See also #1301, #1302, #1335, #1336, #1337, #1338, #1340, #1341, #1347, #1348, #1350, #1383, and #1398.