### PR TITLE
fix: add version and switch to using `pname`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
           default = templ;
 
           templ = pkgs.buildGoModule {
-            name = "templ";
+            pname = "templ";
             version = builtins.readFile ./.version;
             subPackages = [ "cmd/templ" ];
             src = gitignore.lib.gitignoreSource ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
 
           templ = pkgs.buildGoModule {
             name = "templ";
+            version = builtins.readFile ./.version;
             subPackages = [ "cmd/templ" ];
             src = gitignore.lib.gitignoreSource ./.;
             vendorHash = "sha256-byv5yA9y8kp/DHpICX5cgnoFdtv9ztVt3EXR6SWNTN8=";


### PR DESCRIPTION
The version was not added to the nix derivations which made it a bit harder to get the templ version from nix expressions directly. This fixes that by setting the version from the version file.

This also changes to setting `pname` instead of `name` directly. Using `pname` and `version` explicitly allows nix to generate the name of the derivation in the format: `${pname}-${version}`. This is the recommended approach as per the [documentation](https://nixos.org/manual/nixpkgs/stable/#sec-using-stdenv).

NOTE: I did not create an issue for this since it seemed like a small enough change to create a PR directly.