### PR TITLE
fix: dont delete dev-mode text files during a one-off generate

### DIFF
--- a/cmd/templ/generatecmd/cmd.go
+++ b/cmd/templ/generatecmd/cmd.go
@@ -174,9 +174,16 @@ func (cmd Generate) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	// Clean up temporary watch mode text files.
-	if err := cmd.deleteWatchModeTextFiles(); err != nil {
-		cmd.Log.Warn("Failed to delete watch mode text files", slog.Any("error", err))
+	// Clean up temporary watch mode text files. Only do this for watch
+	// sessions: a one-off generate must not delete the text files of a
+	// dev session that is still running, since its server renders from
+	// them (a missing file makes WriteString error out, failing every
+	// render, e.g. running `templ generate` while a `--watch` dev server
+	// is up).
+	if cmd.Args.Watch {
+		if err := cmd.deleteWatchModeTextFiles(); err != nil {
+			cmd.Log.Warn("Failed to delete watch mode text files", slog.Any("error", err))
+		}
 	}
 
 	// Check for errors after everything has completed.

--- a/cmd/templ/generatecmd/eventhandler.go
+++ b/cmd/templ/generatecmd/eventhandler.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"go/format"
 	"go/scanner"
 	"go/token"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path"
@@ -260,7 +262,11 @@ func (h *FSEventHandler) generate(ctx context.Context, fileName string) (result 
 		h.Log.Debug("Writing development mode text file", slog.String("file", fileName), slog.String("output", txtFileName))
 		joined := strings.Join(generatorOutput.Literals, "\n")
 		txtHash := sha256.Sum256([]byte(joined))
-		if h.hashes.CompareAndSwap(txtFileName, syncmap.UpdateIfChanged, txtHash) {
+		// Rewrite the file if the literals changed, or if it vanished from
+		// disk, otherwise the running dev server keeps rendering empty pages
+		// until the literals happen to change.
+		_, statErr := os.Stat(txtFileName)
+		if h.hashes.CompareAndSwap(txtFileName, syncmap.UpdateIfChanged, txtHash) || errors.Is(statErr, fs.ErrNotExist) {
 			if err = os.WriteFile(txtFileName, []byte(joined), 0o644); err != nil {
 				return result, nil, fmt.Errorf("failed to write string literal file %q: %w", txtFileName, err)
 			}

--- a/cmd/templ/generatecmd/main_test.go
+++ b/cmd/templ/generatecmd/main_test.go
@@ -3,7 +3,9 @@ package generatecmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"path"
 	"regexp"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/a-h/templ/cmd/templ/testproject"
 	"github.com/a-h/templ/runtime"
+	"github.com/fsnotify/fsnotify"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -158,6 +161,81 @@ func TestGenerate(t *testing.T) {
 			t.Error("templates_templ.txt was not removed")
 		}
 	})
+	t.Run("a non-watch generate does not delete dev mode text files", func(t *testing.T) {
+		// A one-off `templ generate` must not delete the dev mode text files
+		// of a watch session that may still be running.
+		dir, err := testproject.Create("github.com/a-h/templ/cmd/templ/testproject")
+		if err != nil {
+			t.Fatalf("failed to create test project: %v", err)
+		}
+		t.Cleanup(func() { removeDir(t, dir) })
+
+		// Simulate a running watch session by creating its dev mode text file.
+		txtFile := runtime.GetDevModeTextFileName(path.Join(dir, "templates.templ"))
+		if err := os.WriteFile(txtFile, []byte("existing content"), 0o644); err != nil {
+			t.Fatalf("failed to write dev mode text file: %v", err)
+		}
+		t.Cleanup(func() { removeFile(t, txtFile) })
+
+		if err := Run(context.Background(), io.Discard, io.Discard, []string{"-path", dir}); err != nil {
+			t.Fatalf("failed to run generate command: %v", err)
+		}
+		if _, err := os.Stat(txtFile); err != nil {
+			t.Fatalf("dev mode text file was deleted by a non-watch generate: %v", err)
+		}
+	})
+	t.Run("a missing dev mode text file is recreated on regeneration", func(t *testing.T) {
+		// If the dev mode text file is deleted externally, the next generation
+		// must rewrite it even when the template's literals are unchanged.
+		dir, err := testproject.Create("github.com/a-h/templ/cmd/templ/testproject")
+		if err != nil {
+			t.Fatalf("failed to create test project: %v", err)
+		}
+		t.Cleanup(func() { removeDir(t, dir) })
+
+		fseh := NewFSEventHandler(slog.New(slog.DiscardHandler), dir, true, nil, false, false, FileWriter, false)
+		templFile := path.Join(dir, "templates.templ")
+		txtFile := runtime.GetDevModeTextFileName(templFile)
+		t.Cleanup(func() { removeFile(t, txtFile) })
+
+		event := fsnotify.Event{Name: templFile, Op: fsnotify.Create}
+		if _, err := fseh.HandleEvent(context.Background(), event); err != nil {
+			t.Fatalf("first HandleEvent failed: %v", err)
+		}
+		if _, err := os.Stat(txtFile); err != nil {
+			t.Fatalf("dev mode text file was not created: %v", err)
+		}
+
+		// Delete the file, then regenerate. Content is unchanged (so the hash
+		// matches), but the mod time is bumped to trigger a new event.
+		if err := os.Remove(txtFile); err != nil {
+			t.Fatalf("failed to remove dev mode text file: %v", err)
+		}
+		future := time.Now().Add(time.Hour)
+		if err := os.Chtimes(templFile, future, future); err != nil {
+			t.Fatalf("failed to bump templ file mod time: %v", err)
+		}
+		if _, err := fseh.HandleEvent(context.Background(), event); err != nil {
+			t.Fatalf("second HandleEvent failed: %v", err)
+		}
+		if _, err := os.Stat(txtFile); err != nil {
+			t.Fatalf("dev mode text file was not recreated after deletion: %v", err)
+		}
+	})
+}
+
+func removeDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Errorf("failed to remove test project directory: %v", err)
+	}
+}
+
+func removeFile(t *testing.T, name string) {
+	t.Helper()
+	if err := os.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("failed to remove %q: %v", name, err)
+	}
 }
 
 func TestCheckWriter(t *testing.T) {


### PR DESCRIPTION
## Problem

Running a one-off `templ generate` while a `templ generate --watch` dev server is up breaks every page the running dev server tries to render.

`--watch` writes each template's literals to a temporary `_templ.txt` file; a server run with `TEMPL_DEV_MODE=true` renders from those files. But `generate` called `deleteWatchModeTextFiles()` on every run, including non-watch ones which don't own these files. So a one-off generate deletes the `.txt` files of a separate running watch session, and every render then fails with a missing-file error. The watch session doesn't recover either. It skips rewriting files whose literals are unchanged.

**Repro:** start a watch-mode dev server (`templ generate --watch` plus an app run with `TEMPL_DEV_MODE=true` that renders from the `.txt` files), then run a plain `templ generate` (e.g. a CI/check step that verifies generated code is up to date). The one-off generate wipes the server's `.txt` files and every page then fails to render until the dev session is restarted.

## Fix

- `cmd.go`: only run `deleteWatchModeTextFiles()` in watch mode a one-off generate must not delete files it doesn't own.
- `eventhandler.go`: rewrite a `_templ.txt` file if it's missing from disk, even when literals are unchanged, so a watch session self-heals.

## Tests

Two regression tests in `main_test.go`; a non-watch generate leaves existing `.txt` files intact, and a deleted `.txt` file is recreated on the next regeneration.

## My use case

I run a dev server while also running static checks quite regularly (especially when using AI agents). Each check runs a plain `templ generate`, which was wiping the dev server's `_templ.txt` files and leaving it unable to render any page until I restarted it.

## AI disclaimer

I used Claude to help write the tests and suggest the fix.